### PR TITLE
feat: add iTunes tracklist to CD detail page

### DIFF
--- a/src/hooks/useItunesArt.ts
+++ b/src/hooks/useItunesArt.ts
@@ -1,10 +1,23 @@
 import { useState, useEffect } from 'react'
 
-const cache = new Map<string, string | null>()
+interface CacheEntry {
+  artUrl: string | null
+  collectionId: number | null
+}
+
+const cache = new Map<string, CacheEntry>()
+
+function cacheKey(artist: string, album: string) {
+  return `${artist}|${album}`
+}
+
+export function getItunesCollectionId(artist: string, album: string): number | null {
+  return cache.get(cacheKey(artist, album))?.collectionId ?? null
+}
 
 export function useItunesArt(artist: string, album: string): string | null {
-  const key = `${artist}|${album}`
-  const [url, setUrl] = useState<string | null>(cache.get(key) ?? null)
+  const key = cacheKey(artist, album)
+  const [url, setUrl] = useState<string | null>(cache.get(key)?.artUrl ?? null)
   const [tried, setTried] = useState(cache.has(key))
 
   useEffect(() => {
@@ -20,13 +33,15 @@ export function useItunesArt(artist: string, album: string): string | null {
           { signal: controller.signal },
         )
         const data = await res.json()
+        const result = data.results?.[0]
         const artUrl: string | null =
-          data.results?.[0]?.artworkUrl100?.replace('100x100', '600x600') ?? null
-        cache.set(key, artUrl)
+          result?.artworkUrl100?.replace('100x100', '600x600') ?? null
+        const collectionId: number | null = result?.collectionId ?? null
+        cache.set(key, { artUrl, collectionId })
         setUrl(artUrl)
       } catch {
         if (!controller.signal.aborted) {
-          cache.set(key, null)
+          cache.set(key, { artUrl: null, collectionId: null })
         }
       }
       setTried(true)

--- a/src/hooks/useItunesTracks.ts
+++ b/src/hooks/useItunesTracks.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react'
+import { getItunesCollectionId } from './useItunesArt'
+
+export interface ItunesTrack {
+  name: string
+  trackNumber: number
+  discNumber: number
+  durationMs: number
+}
+
+const trackCache = new Map<number, ItunesTrack[]>()
+
+export function useItunesTracks(artist: string, album: string): { tracks: ItunesTrack[]; loading: boolean } {
+  const [tracks, setTracks] = useState<ItunesTrack[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    const controller = new AbortController()
+
+    async function fetchTracks() {
+      // Wait for useItunesArt to populate the collectionId cache
+      let collectionId: number | null = null
+      for (let i = 0; i < 20; i++) {
+        collectionId = getItunesCollectionId(artist, album)
+        if (collectionId !== null) break
+        await new Promise(r => setTimeout(r, 250))
+      }
+
+      if (!collectionId || cancelled) {
+        if (!cancelled) setLoading(false)
+        return
+      }
+
+      // Check cache
+      const cached = trackCache.get(collectionId)
+      if (cached) {
+        if (!cancelled) {
+          setTracks(cached)
+          setLoading(false)
+        }
+        return
+      }
+
+      try {
+        const res = await fetch(
+          `https://itunes.apple.com/lookup?id=${collectionId}&entity=song`,
+          { signal: controller.signal },
+        )
+        const data = await res.json()
+        const results: ItunesTrack[] = (data.results ?? [])
+          .filter((r: Record<string, unknown>) => r.wrapperType === 'track')
+          .map((r: Record<string, unknown>) => ({
+            name: r.trackName as string,
+            trackNumber: r.trackNumber as number,
+            discNumber: r.discNumber as number,
+            durationMs: r.trackTimeMillis as number,
+          }))
+          .sort((a: ItunesTrack, b: ItunesTrack) =>
+            a.discNumber !== b.discNumber
+              ? a.discNumber - b.discNumber
+              : a.trackNumber - b.trackNumber,
+          )
+        trackCache.set(collectionId, results)
+        if (!cancelled) {
+          setTracks(results)
+          setLoading(false)
+        }
+      } catch {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    fetchTracks()
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [artist, album])
+
+  return { tracks, loading }
+}

--- a/src/pages/CdDetailPage.tsx
+++ b/src/pages/CdDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link, Navigate } from 'react-router-dom'
 import type { CdItem } from '@/types/cd'
 import { useItunesArt } from '@/hooks/useItunesArt'
+import { useItunesTracks, type ItunesTrack } from '@/hooks/useItunesTracks'
 import { getTagColor, getGenreColor } from '@/lib/colors'
 import { spotifySearchUrl, youtubeSearchUrl } from '@/lib/links'
 import Badge from '@/components/shared/Badge'
@@ -17,8 +18,54 @@ export default function CdDetailPage() {
   return <CdDetail cd={cd} />
 }
 
+function formatTrackDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+function Tracklist({ tracks }: { tracks: ItunesTrack[] }) {
+  const maxDisc = Math.max(...tracks.map(t => t.discNumber))
+  const multiDisc = maxDisc > 1
+
+  const byDisc = new Map<number, ItunesTrack[]>()
+  for (const t of tracks) {
+    const list = byDisc.get(t.discNumber) ?? []
+    list.push(t)
+    byDisc.set(t.discNumber, list)
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm text-muted-dark uppercase tracking-wider font-medium">Tracklist</h2>
+      {Array.from(byDisc.entries()).map(([disc, discTracks]) => (
+        <div key={disc}>
+          {multiDisc && (
+            <p className="text-xs text-muted font-medium mb-2">Disc {disc}</p>
+          )}
+          <ol className="space-y-0.5">
+            {discTracks.map(t => (
+              <li key={`${t.discNumber}-${t.trackNumber}`} className="flex items-baseline gap-3 py-1 text-sm border-b border-surface-light/50 last:border-0">
+                <span className="text-muted-dark font-mono text-xs w-5 text-right shrink-0">
+                  {t.trackNumber}
+                </span>
+                <span className="text-foreground truncate flex-1">{t.name}</span>
+                <span className="text-muted-dark font-mono text-xs shrink-0">
+                  {formatTrackDuration(t.durationMs)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function CdDetail({ cd }: { cd: CdItem }) {
   const artUrl = useItunesArt(cd.artist, cd.title)
+  const { tracks, loading: tracksLoading } = useItunesTracks(cd.artist, cd.title)
 
   return (
     <div className="px-4 py-8 pb-24 sm:pb-8">
@@ -82,6 +129,16 @@ function CdDetail({ cd }: { cd: CdItem }) {
               {cd.composer && <MetaItem label="Composer" value={cd.composer} />}
               {cd.conductor && <MetaItem label="Conductor" value={cd.conductor} />}
             </dl>
+
+            {/* Tracklist */}
+            {tracksLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted py-2">
+                <div className="h-4 w-4 animate-spin rounded-full border border-amber/40 border-t-amber" />
+                Loading tracklist...
+              </div>
+            ) : tracks.length > 0 ? (
+              <Tracklist tracks={tracks} />
+            ) : null}
 
             {/* External links */}
             <div className="flex items-center gap-3 pt-2">


### PR DESCRIPTION
## Summary
- Fetch track listings from the iTunes Lookup API and display them on the CD detail page
- Tracks shown with numbers and formatted durations (mm:ss), grouped by disc for multi-disc albums
- Refactored `useItunesArt` to cache `collectionId` from iTunes search results (no breaking changes to existing consumers)
- New `useItunesTracks` hook with in-memory caching and abort controller support

## Test plan
- [ ] Open a CD detail page (e.g., Miles Davis album) — tracklist should appear below metadata
- [ ] Check a multi-disc album — should show "Disc 1" / "Disc 2" headers
- [ ] Check an obscure album not on iTunes — no tracklist section, no errors
- [ ] Verify cover art still loads correctly on browse and home pages (no regression from useItunesArt refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)