### PR TITLE
feat: add Vinyl coming soon tab to mobile navigation

### DIFF
--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -5,6 +5,7 @@ const tabs = [
   { to: '/browse/cds', label: 'CDs', icon: DiscIcon },
   { to: '/browse/dvds', label: 'DVDs', icon: FilmIcon },
   { to: '/insights', label: 'Insights', icon: ChartIcon },
+  { to: '/vinyl', label: 'Vinyl', icon: VinylIcon, badge: 'Soon' },
 ]
 
 function HomeIcon({ className }: { className?: string }) {
@@ -50,6 +51,16 @@ function ChartIcon({ className }: { className?: string }) {
   )
 }
 
+function VinylIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="6" />
+      <circle cx="12" cy="12" r="2" />
+    </svg>
+  )
+}
+
 export default function BottomNav() {
   return (
     <nav className="md:hidden fixed bottom-0 inset-x-0 z-50 border-t border-surface-light bg-background/95 backdrop-blur-sm safe-area-pb">
@@ -60,13 +71,18 @@ export default function BottomNav() {
             to={tab.to}
             end={tab.to === '/'}
             className={({ isActive }) =>
-              `flex flex-col items-center gap-0.5 px-3 py-2 min-w-[64px] transition-colors ${
+              `relative flex flex-col items-center gap-0.5 px-3 py-2 min-w-[52px] transition-colors ${
                 isActive ? 'text-amber' : 'text-muted'
               }`
             }
           >
             <tab.icon className="h-5 w-5" />
             <span className="text-[10px] font-medium">{tab.label}</span>
+            {'badge' in tab && tab.badge && (
+              <span className="absolute -top-0.5 right-0.5 rounded-full bg-amber/20 px-1 py-px text-[7px] font-mono text-amber leading-tight">
+                {tab.badge}
+              </span>
+            )}
           </NavLink>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Adds Vinyl tab with "Soon" badge to the mobile bottom navigation (BottomNav)
- Matches the desktop Navbar which already shows Vinyl with a "Soon" badge
- Includes a new VinylIcon (three concentric circles resembling a vinyl record)
- Slightly reduced tab min-width to fit 5 tabs comfortably

## Test plan
- [ ] Mobile: 5 tabs visible in bottom nav (Home, CDs, DVDs, Insights, Vinyl)
- [ ] Vinyl tab shows "Soon" badge in top-right corner
- [ ] Tapping Vinyl navigates to /vinyl (Coming Soon page)
- [ ] Active state highlights correctly in amber
- [ ] Desktop navbar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)