### PR TITLE
fix: fill cover art marquee gaps on wide screens

### DIFF
--- a/src/components/home/CoverArtMarquee.tsx
+++ b/src/components/home/CoverArtMarquee.tsx
@@ -11,6 +11,9 @@ const NOTABLE_LABELS = new Set([
   'Blue Note', 'Verve', 'Columbia', 'Prestige', 'Impulse!', 'ECM',
   'Atlantic', 'Riverside', 'Fantasy', 'CTI', 'Pacific Jazz',
   'Concord', 'Pablo', 'Savoy', 'Contemporary',
+  'Decca', 'Mercury', 'Warner Bros.', 'Capitol', 'Nonesuch',
+  'A&M', 'Island', 'Elektra', 'RCA Victor', 'Reprise',
+  'Polydor', 'Philips', 'MCA', 'Epic', 'Geffen',
 ])
 
 function pickMarqueeCds(cds: CdItem[], count: number): CdItem[] {
@@ -41,14 +44,7 @@ function CoverTile({ cd }: { cd: CdItem }) {
   const artUrl = useItunesArt(cd.artist, cd.title)
 
   if (!artUrl) {
-    return (
-      <div className="flex-none w-20 h-20 sm:w-24 sm:h-24 rounded-lg bg-surface-hover border border-surface-light flex items-center justify-center overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-amber/5 to-copper/5" />
-        <p className="text-[8px] text-muted-dark text-center px-1 leading-tight line-clamp-2 relative">
-          {cd.title}
-        </p>
-      </div>
-    )
+    return null
   }
 
   return (
@@ -85,12 +81,12 @@ function MarqueeRow({ cds, direction }: { cds: CdItem[]; direction: 'left' | 'ri
 }
 
 export default function CoverArtMarquee({ cds }: CoverArtMarqueeProps) {
-  const row1 = useMemo(() => pickMarqueeCds(cds, 16), [cds])
+  const row1 = useMemo(() => pickMarqueeCds(cds, 40), [cds])
   const row2 = useMemo(() => {
     // Pick a different set for row 2
     const row1Ids = new Set(row1.map(c => c.id))
     const remaining = cds.filter(c => !row1Ids.has(c.id))
-    return pickMarqueeCds(remaining, 16)
+    return pickMarqueeCds(remaining, 40)
   }, [cds, row1])
 
   return (


### PR DESCRIPTION
## Summary
- Increased marquee tile count from 16 to 40 per row to fill ultra-wide monitors (3840px+)
- Tiles without iTunes cover art now render as `null` instead of text fallback placeholders — only real album covers are shown
- Expanded `NOTABLE_LABELS` with 15 more internationally recognized labels (Decca, Mercury, Warner Bros., Capitol, RCA Victor, Epic, etc.) for better iTunes match rate

## Test plan
- [ ] Open home page on a wide monitor (2560px+) — marquee should be fully filled with cover art
- [ ] Verify no blank/text-only placeholder tiles appear
- [ ] Check seamless looping still works on both rows
- [ ] Test on mobile viewport — should still look good

🤖 Generated with [Claude Code](https://claude.ai/code)