### PR TITLE
fix: add i18n translations to SearchPage

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -169,6 +169,18 @@ export const en: Translations = {
     description: 'This section is being curated. A collection of vinyl records will be added here soon.',
     stayTuned: 'Stay tuned.',
   },
+  search: {
+    title: 'Search',
+    placeholder: 'Search artists, albums, directors, genres...',
+    promptMessage: 'Search across all collections — CDs, DVDs, and more',
+    emptyTitle: 'Even Panqueca couldn\'t find what you\'re looking for!',
+    emptyHint: 'Try a different search term',
+    emptyAlt: 'Panqueca the dog searching',
+    foundSummary: 'Found {{cdCount}} CDs and {{dvdCount}} DVDs matching "{{query}}"',
+    result: 'result',
+    results: 'results',
+    viewAll: 'View all {{count}}',
+  },
   common: {
     clearSearch: 'Clear search',
     more: '+{{count}} more',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -169,6 +169,18 @@ export const pt: Translations = {
     description: 'Esta seção está sendo curada. Uma coleção de discos de vinil será adicionada em breve.',
     stayTuned: 'Fique ligado.',
   },
+  search: {
+    title: 'Busca',
+    placeholder: 'Buscar artistas, álbuns, diretores, gêneros...',
+    promptMessage: 'Busque em todas as coleções — CDs, DVDs e mais',
+    emptyTitle: 'Até a Panqueca procurou e não encontrou!',
+    emptyHint: 'Tente um termo de busca diferente',
+    emptyAlt: 'Panqueca, a cachorra, procurando',
+    foundSummary: 'Encontrados {{cdCount}} CDs e {{dvdCount}} DVDs para "{{query}}"',
+    result: 'resultado',
+    results: 'resultados',
+    viewAll: 'Ver todos ({{count}})',
+  },
   common: {
     clearSearch: 'Limpar busca',
     more: '+{{count}} mais',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -169,6 +169,18 @@ export interface Translations {
     description: string
     stayTuned: string
   }
+  search: {
+    title: string
+    placeholder: string
+    promptMessage: string
+    emptyTitle: string
+    emptyHint: string
+    emptyAlt: string
+    foundSummary: string
+    result: string
+    results: string
+    viewAll: string
+  }
   common: {
     clearSearch: string
     more: string

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -6,6 +6,7 @@ import type { CdItem } from '@/types/cd'
 import type { DvdItem } from '@/types/dvd'
 import { searchItems } from '@/lib/search'
 import { formatNumber } from '@/lib/format'
+import { useLanguage } from '@/i18n'
 import SearchBar from '@/components/shared/SearchBar'
 import CdCard from '@/components/cd/CdCard'
 import DvdCard from '@/components/dvd/DvdCard'
@@ -18,11 +19,15 @@ function ResultSection({
   title,
   count,
   browseUrl,
+  viewAllLabel,
+  resultLabel,
   children,
 }: {
   title: string
   count: number
   browseUrl: string
+  viewAllLabel: string
+  resultLabel: string
   children: React.ReactNode
 }) {
   return (
@@ -31,7 +36,7 @@ function ResultSection({
         <h2 className="font-display text-xl text-foreground">
           {title}
           <span className="ml-2 text-sm text-muted font-sans">
-            {formatNumber(count)} {count === 1 ? 'result' : 'results'}
+            {formatNumber(count)} {resultLabel}
           </span>
         </h2>
         {count > PREVIEW_COUNT && (
@@ -39,7 +44,7 @@ function ResultSection({
             to={browseUrl}
             className="text-sm text-amber hover:text-amber-light transition-colors whitespace-nowrap"
           >
-            View all {formatNumber(count)} &rarr;
+            {viewAllLabel} &rarr;
           </Link>
         )}
       </div>
@@ -53,6 +58,7 @@ function ResultSection({
 export default function SearchPage() {
   const [params, setParams] = useSearchParams()
   const query = params.get('q') || ''
+  const { t } = useLanguage()
 
   const cdResults = useMemo(() => searchItems(cdData, query), [query])
   const dvdResults = useMemo(() => searchItems(dvdData, query), [query])
@@ -67,42 +73,45 @@ export default function SearchPage() {
   return (
     <div className="px-4 py-6">
       <div className="mx-auto max-w-5xl space-y-6">
-        <h1 className="font-display text-3xl text-amber">Search</h1>
+        <h1 className="font-display text-3xl text-amber">{t('search.title')}</h1>
 
         <div className="sticky top-16 z-10 bg-background/95 backdrop-blur-sm pb-3">
           <SearchBar
             value={query}
             onChange={handleQueryChange}
-            placeholder="Search artists, albums, directors, genres..."
+            placeholder={t('search.placeholder')}
             large
           />
         </div>
 
         {!hasQuery && (
           <p className="text-center text-muted py-12">
-            Search across all collections — CDs, DVDs, and more
+            {t('search.promptMessage')}
           </p>
         )}
 
         {hasQuery && totalResults === 0 && (
           <div className="text-center py-16 space-y-5">
             <p className="font-display text-2xl text-amber">
-              Even Panqueca couldn't find what you're looking for!
+              {t('search.emptyTitle')}
             </p>
             <img
               src={`${import.meta.env.BASE_URL}panqueca-not-found.jpeg`}
-              alt="Panqueca the dog searching"
+              alt={t('search.emptyAlt')}
               className="mx-auto w-80 sm:w-96 rounded-xl shadow-lg"
             />
-            <p className="text-muted-dark text-sm">Try a different search term</p>
+            <p className="text-muted-dark text-sm">{t('search.emptyHint')}</p>
           </div>
         )}
 
         {hasQuery && totalResults > 0 && (
           <>
             <p className="text-xs text-muted">
-              Found {formatNumber(cdResults.length)} CDs and{' '}
-              {formatNumber(dvdResults.length)} DVDs matching &ldquo;{query}&rdquo;
+              {t('search.foundSummary', {
+                cdCount: formatNumber(cdResults.length),
+                dvdCount: formatNumber(dvdResults.length),
+                query,
+              })}
             </p>
 
             {cdResults.length > 0 && (
@@ -110,6 +119,8 @@ export default function SearchPage() {
                 title="CDs"
                 count={cdResults.length}
                 browseUrl={`/browse/cds?q=${encodeURIComponent(query)}`}
+                viewAllLabel={t('search.viewAll', { count: formatNumber(cdResults.length) })}
+                resultLabel={cdResults.length === 1 ? t('search.result') : t('search.results')}
               >
                 {cdResults.slice(0, PREVIEW_COUNT).map(cd => (
                   <CdCard key={cd.id} cd={cd} />
@@ -122,6 +133,8 @@ export default function SearchPage() {
                 title="DVDs"
                 count={dvdResults.length}
                 browseUrl={`/browse/dvds?q=${encodeURIComponent(query)}`}
+                viewAllLabel={t('search.viewAll', { count: formatNumber(dvdResults.length) })}
+                resultLabel={dvdResults.length === 1 ? t('search.result') : t('search.results')}
               >
                 {dvdResults.slice(0, PREVIEW_COUNT).map(dvd => (
                   <DvdCard key={dvd.id} dvd={dvd} />


### PR DESCRIPTION
## Summary
- **SearchPage.tsx** had all text hardcoded in English — the only page without i18n support
- Added a `search` translation namespace to `types.ts`, `en.ts`, and `pt.ts`
- Updated SearchPage to use `useLanguage()` hook for all user-facing strings
- Covers: page title, search placeholder, empty state (Panqueca message), results summary, "View all" links, and result/results pluralization

## Audit of all pages
| Page | i18n Status |
|------|------------|
| HomePage | Already translated |
| BrowsePage | Already translated |
| CdDetailPage | Already translated (brand names like Spotify/YouTube stay as-is) |
| DvdDetailPage | Already translated (brand names like IMDb/Google stay as-is) |
| InsightsPage | Already translated |
| VinylPage | Already translated |
| NotFoundPage | Already translated (Panqueca error page) |
| **SearchPage** | **Fixed in this PR** |

## Test plan
- [ ] Switch language to PT and navigate to Search page — all labels should be in Portuguese
- [ ] Search for a term with results — verify "Encontrados X CDs e Y DVDs" summary
- [ ] Search for a term with no results — verify Panqueca empty state in Portuguese
- [ ] Visit Search page with no query — verify prompt message in Portuguese
- [ ] Verify EN language still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)