### PR TITLE
feat: add --delay flag to artwork script and retry missed CDs

### DIFF
--- a/artwork-cache.json
+++ b/artwork-cache.json
@@ -77,7 +77,7 @@
   "cd-15-ahmad-jamal-chicago-revisited-live-at-jo": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:34.890Z"
+    "resolvedAt": "2026-03-27T10:34:08.045Z"
   },
   "cd-16-ahmad-jamal-crystal": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/v4/6b/60/ae/6b60aeb1-77b9-8863-8e57-0be5428d4b80/dj.mwzuqxll.jpg/600x600bb.jpg",
@@ -127,7 +127,7 @@
   "cd-25-johnny-alf-o-que-e-amar": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:42.790Z"
+    "resolvedAt": "2026-03-27T10:34:11.589Z"
   },
   "cd-26-johnny-alf-olhos-negros": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/70/93/5d/mzi.swpphssu.jpg/600x600bb.jpg",
@@ -137,12 +137,12 @@
   "cd-27-altemar-dutra-bis": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:44.744Z"
+    "resolvedAt": "2026-03-27T10:34:14.306Z"
   },
   "cd-28-ataulfo-alves-mpb-compositores-ataulfo-a": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:46.438Z"
+    "resolvedAt": "2026-03-27T10:34:17.430Z"
   },
   "cd-29-rica-amabis-sambadelic": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ba/42/3c/mzi.hjuovjmj.jpg/600x600bb.jpg",
@@ -152,7 +152,7 @@
   "cd-30-amazonas-filarmonica-coral-do-amazonas-m": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:48.464Z"
+    "resolvedAt": "2026-03-27T10:34:20.344Z"
   },
   "cd-31-american-composers-orchestra-four-sympho": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/00/bf/aa/00bfaa8f-6406-88e6-879c-92a9f0acb6b1/884385528324.jpg/600x600bb.jpg",
@@ -197,7 +197,7 @@
   "cd-39-the-andre-previn-trio-give-my-regards-to": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:52.285Z"
+    "resolvedAt": "2026-03-27T10:34:23.044Z"
   },
   "cd-40-angela-maria-amigos": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ff/77/10/mzi.wdyzxhjm.jpg/600x600bb.jpg",
@@ -212,7 +212,7 @@
   "cd-42-antonio-hart-for-cannonball-and-woody": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:55.627Z"
+    "resolvedAt": "2026-03-27T10:34:27.033Z"
   },
   "cd-43-antonio-hart-here-i-stand": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/a3/b9/c1/a3b9c197-555a-8750-4ba4-d6cf44554f1f/00602577538247.rgb.jpg/600x600bb.jpg",
@@ -227,7 +227,7 @@
   "cd-45-antulio-madureira-teatro-instrumental": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:29:57.811Z"
+    "resolvedAt": "2026-03-27T10:34:29.773Z"
   },
   "cd-46-arnaldo-antunes-ie-ie-ie": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/2d/95/c3/2d95c36a-45f7-8ee5-88f5-02fee8d11562/8429006278961.jpg/600x600bb.jpg",
@@ -247,7 +247,7 @@
   "cd-49-aquarela-sonora-estacao-suburbana": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:00.796Z"
+    "resolvedAt": "2026-03-27T10:34:32.784Z"
   },
   "cd-50-aquilo-del-nisso-chico-buarque-instrumen": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/1c/fb/a2/1cfba2b8-53c7-4892-85fb-cd7d605b5874/0.jpg/600x600bb.jpg",
@@ -262,7 +262,7 @@
   "cd-52-guilherme-arantes-millenium": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:02.971Z"
+    "resolvedAt": "2026-03-27T10:34:35.498Z"
   },
   "cd-53-arire-arire": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music20/v4/e2/81/d0/e281d029-5287-f7bc-d236-033a9e1af0fa/190374849210.jpg/600x600bb.jpg",
@@ -277,7 +277,7 @@
   "cd-55-armandinho-retocando-o-choro": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:05.431Z"
+    "resolvedAt": "2026-03-27T10:34:38.435Z"
   },
   "cd-56-louis-armstrong-20-super-sucessos": {
     "url": "http://coverartarchive.org/release/e914022f-3f43-47c4-9134-c434cee1de2c/21388672741-500.jpg",
@@ -317,7 +317,7 @@
   "cd-63-art-popular-acustico-mtv": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:17.081Z"
+    "resolvedAt": "2026-03-27T10:34:41.432Z"
   },
   "cd-64-art-tatum-a-jazz-hour-with-art-tatum": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/0d/62/7d/0d627d88-d0dd-260b-db55-662f774feaac/00731454376129.rgb.jpg/600x600bb.jpg",
@@ -342,7 +342,7 @@
   "cd-68-arthur-h-lenine-le-voyage-de-la-lune-et-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:19.820Z"
+    "resolvedAt": "2026-03-27T10:34:44.202Z"
   },
   "cd-69-the-artist-formerly-known-as-prince-the-": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/da/a6/c1/daa6c196-2de6-8571-7642-b0b5c1b8278b/603497857982.jpg/600x600bb.jpg",
@@ -357,22 +357,22 @@
   "cd-71-ary-barroso-songbook-ary-barroso-volume-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:22.281Z"
+    "resolvedAt": "2026-03-27T10:34:47.024Z"
   },
   "cd-72-ary-barroso-songbook-ary-barroso-volume-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:24.140Z"
+    "resolvedAt": "2026-03-27T10:34:49.736Z"
   },
   "cd-73-ary-barroso-songbook-ary-barroso-volume-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:25.851Z"
+    "resolvedAt": "2026-03-27T10:34:52.529Z"
   },
   "cd-74-astor-piazzolla-gerry-mulligan-summit-re": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:27.552Z"
+    "resolvedAt": "2026-03-27T10:34:55.306Z"
   },
   "cd-75-astral-project-voodoobop": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/y2004/m11/d30/h07/s05.yskiqjdy.jpg/600x600bb.jpg",
@@ -382,7 +382,7 @@
   "cd-76-augusto-calheiros-augusto-calheiros-revi": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:30:29.829Z"
+    "resolvedAt": "2026-03-27T10:34:58.984Z"
   },
   "cd-77-charles-aznavour-charles-aznavour": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/88/2d/1d/882d1d8c-e06b-04c3-44e4-5d939e832d6f/13UAAIM43821.rgb.jpg/600x600bb.jpg",
@@ -467,7 +467,7 @@
   "cd-93-caio-barini-texturas": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:01.872Z"
+    "resolvedAt": "2026-03-27T10:35:01.781Z"
   },
   "cd-94-bate-lata-gente-e-pra-brilhar-nao-pra-mo": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/7e/0e/ab/7e0eab38-f253-51bd-bb22-c44a2244a6f5/0.jpg/600x600bb.jpg",
@@ -532,7 +532,7 @@
   "cd-106-walter-becker-11-tracks-of-whack": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:08.954Z"
+    "resolvedAt": "2026-03-27T10:35:07.402Z"
   },
   "cd-107-walter-becker-donald-fagen-founders-of-s": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/c2/3c/54/c23c5414-20d1-7aea-f0f5-187974c58d65/23UMGIM79990.rgb.jpg/600x600bb.jpg",
@@ -557,7 +557,7 @@
   "cd-111-edson-beltrami-viii-premio-eldorado-de-m": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:15.117Z"
+    "resolvedAt": "2026-03-27T10:35:10.366Z"
   },
   "cd-112-tony-bennett-duets-ii": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/55/97/94/5597940f-5e03-5e1d-7c92-4c2328efab46/886443116818.jpg/600x600bb.jpg",
@@ -587,7 +587,7 @@
   "cd-117-berger-rudi-innocent-onvader": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:18.114Z"
+    "resolvedAt": "2026-03-27T10:35:13.263Z"
   },
   "cd-118-bernard-purdie-bernard-purdie-s-soul-to-": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/d9/19/17/d91917e8-0bd0-fca1-64e7-79f9fb4e5767/cover.jpg/600x600bb.jpg",
@@ -602,12 +602,12 @@
   "cd-120-bessie-smith-bessie-smith-1925-1933": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:22.948Z"
+    "resolvedAt": "2026-03-27T10:35:18.971Z"
   },
   "cd-121-maria-bethania-acervo-especial": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:25.258Z"
+    "resolvedAt": "2026-03-27T10:35:21.992Z"
   },
   "cd-122-maria-bethania-maricotinha": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/d5/df/33/d5df33c2-bf22-c88f-2505-617afb8dc3ed/7898324755217.jpg/600x600bb.jpg",
@@ -717,7 +717,7 @@
   "cd-143-bill-evans-and-others-the-blues-and-the-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:44.421Z"
+    "resolvedAt": "2026-03-27T10:35:24.920Z"
   },
   "cd-144-bill-evans-trio-sunday-at-the-village-va": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/3d/f2/ab/3df2ab45-5e51-b4b6-07dd-daefe8c0ecbc/00888072305090.rgb.jpg/600x600bb.jpg",
@@ -742,12 +742,12 @@
   "cd-148-billie-holiday-quintessential-vol-5-1937": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:47.099Z"
+    "resolvedAt": "2026-03-27T10:35:27.615Z"
   },
   "cd-149-billie-holiday-the-complete-billie-holid": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:48.801Z"
+    "resolvedAt": "2026-03-27T10:35:30.345Z"
   },
   "cd-150-billie-holiday-the-diva-series-billie-ho": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/b8/66/18/b866186c-bf6b-16b6-8b10-fd685481c69c/06UMGIM09796.rgb.jpg/600x600bb.jpg",
@@ -757,7 +757,7 @@
   "cd-151-billie-holiday-the-revue-collection": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:51.471Z"
+    "resolvedAt": "2026-03-27T10:35:33.271Z"
   },
   "cd-152-billy-cobham-the-best-of": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f9/57/ef/mzi.iixkmfke.jpg/600x600bb.jpg",
@@ -772,7 +772,7 @@
   "cd-154-billy-strayhorn-lush-life-the-billy-stra": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:53.686Z"
+    "resolvedAt": "2026-03-27T10:35:36.043Z"
   },
   "cd-155-billy-strayhorn-peaceful-side": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/ce/3e/c4/ce3ec44d-cc48-6b2b-f2c2-e2750029f99f/19UMGIM06117.rgb.jpg/600x600bb.jpg",
@@ -782,7 +782,7 @@
   "cd-156-alexis-bittencourt-bandarra-degelo": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:31:56.209Z"
+    "resolvedAt": "2026-03-27T10:35:38.771Z"
   },
   "cd-157-bix-beiderbecke-golden-age-of-bix-beider": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/c8/09/eb/c809eb02-2d96-a5e7-bc8f-af557767adef/5099926677552_1500x1500_300dpi.jpg/600x600bb.jpg",
@@ -827,7 +827,7 @@
   "cd-165-blossom-dearie-songs-of-chelsea": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:32:14.133Z"
+    "resolvedAt": "2026-03-27T10:35:42.381Z"
   },
   "cd-166-blossom-dearie-verve-jazz-masters-51": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/41/8f/e9/418fe9c7-8cb2-e0ff-8686-ed9475102d0a/00731452990624.rgb.jpg/600x600bb.jpg",
@@ -847,7 +847,7 @@
   "cd-169-bob-freitas-nego-nelson-solos-do-nosso-s": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:32:16.580Z"
+    "resolvedAt": "2026-03-27T10:35:45.151Z"
   },
   "cd-170-bob-mintzer-big-band-quality-time": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music71/v4/c9/b5/24/c9b52413-f422-7c8a-9d3a-0d1bbe0e29c0/612262104022.jpg/600x600bb.jpg",
@@ -867,7 +867,7 @@
   "cd-173-boca-livre-20-anos-boca-livre-convida": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:32:18.994Z"
+    "resolvedAt": "2026-03-27T10:35:47.866Z"
   },
   "cd-174-boca-livre-amizade": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music1/v4/c7/a0/c5/c7a0c5e8-0f87-d131-b45c-e8ecc9664889/7891430379124.jpg/600x600bb.jpg",
@@ -882,7 +882,7 @@
   "cd-176-bocato-samba-de-zamba": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:32:21.226Z"
+    "resolvedAt": "2026-03-27T10:35:50.577Z"
   },
   "cd-177-andrea-bocelli-viaggio-italiano": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/d8/c0/e1/d8c0e14b-ea6b-5a21-1fd4-e5ef864a2091/00731453312326.rgb.jpg/600x600bb.jpg",
@@ -897,7 +897,7 @@
   "cd-179-bpm-vol-1-faixas-de-next-brazilian-vibe-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:32:23.431Z"
+    "resolvedAt": "2026-03-27T10:35:53.331Z"
   },
   "cd-180-branford-marsalis-bloomington": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/d4/a2/5f/dj.qvpoxkgu.jpg/600x600bb.jpg",
@@ -952,7 +952,7 @@
   "cd-190-brazz-jazz-kick-off-your-shoes": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:32:27.950Z"
+    "resolvedAt": "2026-03-27T10:35:56.116Z"
   },
   "cd-191-james-brown-sex-machine": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/17/8b/05/178b05de-5855-0136-9827-a0e8a6ccf3db/00602547021656.rgb.jpg/600x600bb.jpg",
@@ -1065,9 +1065,9 @@
     "resolvedAt": "2026-03-26T17:32:53.517Z"
   },
   "cd-213-olivia-byington-a-dama-do-encantado": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:32:55.696Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/ef/65/da/ef65da49-9abd-b2c9-2195-4a38534f366e/7898324755866.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:35:57.380Z"
   },
   "cd-214-cab-calloway-best-of-the-big-bands-cab-c": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/45/e4/74/mzi.iyjqoeog.jpg/600x600bb.jpg",
@@ -1097,7 +1097,7 @@
   "cd-219-caetano-veloso-jaques-morelenbaum-o-quat": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:02.191Z"
+    "resolvedAt": "2026-03-27T10:36:00.155Z"
   },
   "cd-220-maria-callas-the-legend": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/b6/e1/13/b6e1130b-8b54-1e29-4d4a-6ec6b5d25e73/0724355705754_1417x1417_300dpi.jpg/600x600bb.jpg",
@@ -1142,7 +1142,7 @@
   "cd-228-carlos-careqa-ladeira-da-memoria-afluent": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:05.990Z"
+    "resolvedAt": "2026-03-27T10:36:02.930Z"
   },
   "cd-229-os-cariocas-os-cariocas": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/fb/7e/0c/fb7e0ceb-bdd6-508d-719e-c3ae9debc029/cover.jpg/600x600bb.jpg",
@@ -1167,7 +1167,7 @@
   "cd-233-carlos-lyra-colecao-folha-50-anos-de-bos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:08.688Z"
+    "resolvedAt": "2026-03-27T10:36:05.992Z"
   },
   "cd-234-roberto-carlos-acustico-mtv": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/79/78/08/797808d1-00aa-821b-b905-e715259f6604/886447199084.jpg/600x600bb.jpg",
@@ -1212,12 +1212,12 @@
   "cd-242-carmina-demo-97": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:12.394Z"
+    "resolvedAt": "2026-03-27T10:36:08.758Z"
   },
   "cd-243-carmina-mega-hits-internacionais": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:14.235Z"
+    "resolvedAt": "2026-03-27T10:36:11.575Z"
   },
   "cd-244-carol-sloane-out-of-the-blue": {
     "url": "https://coverartarchive.org/release/d8aa74c7-0f0f-4023-a376-625fd59da804/40449477704-500.jpg",
@@ -1242,7 +1242,7 @@
   "cd-248-cartola-entre-amigos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:24.628Z"
+    "resolvedAt": "2026-03-27T10:36:15.128Z"
   },
   "cd-249-cassandra-wilson-belly-of-the-sun": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/8e/0c/6e/8e0c6ec8-f173-2c94-c545-f23ab2421cf6/00724353507251.jpg/600x600bb.jpg",
@@ -1297,12 +1297,12 @@
   "cd-259-nana-caymmi-bolero": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:40.834Z"
+    "resolvedAt": "2026-03-27T10:36:18.180Z"
   },
   "cd-260-cecelo-frony-trio-cecelo-frony-trio": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:33:42.771Z"
+    "resolvedAt": "2026-03-27T10:36:20.816Z"
   },
   "cd-261-cecilia-bartoli-myung-whun-chung-chant-d": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/aa/78/38/aa783862-6435-88ec-bba2-631529d84575/06UMGIM64513.rgb.jpg/600x600bb.jpg",
@@ -1392,7 +1392,7 @@
   "cd-278-charlie-haden-hank-jones-steal-away-spir": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:34:04.043Z"
+    "resolvedAt": "2026-03-27T10:36:23.559Z"
   },
   "cd-279-charlie-haden-jan-garbarek-egberto-gismo": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/38/c9/4e/38c94e2e-8c0a-3255-4869-9a8cfc450385/21UMGIM37898.rgb.jpg/600x600bb.jpg",
@@ -1525,9 +1525,9 @@
     "resolvedAt": "2026-03-26T17:34:46.258Z"
   },
   "cd-305-chick-corea-originations": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:34:48.752Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/8a/42/64/8a42643a-312c-e745-aecd-9f96cdd2b4b5/00013431903420.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:36:24.919Z"
   },
   "cd-306-chick-corea-rendezvous-in-new-york": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/4b/04/fb/4b04fbde-b76c-40e0-2d15-357d108f997f/00013431904120.rgb.jpg/600x600bb.jpg",
@@ -1557,7 +1557,7 @@
   "cd-311-choralschola-der-wiener-hofburgkapelle-h": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:04.809Z"
+    "resolvedAt": "2026-03-27T10:36:27.680Z"
   },
   "cd-312-chris-botti-midnight-without-you": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/3a/c0/a8/3ac0a8e9-8212-4af4-7f98-b59c470f4d02/00731453713222.rgb.jpg/600x600bb.jpg",
@@ -1612,17 +1612,17 @@
   "cd-322-christopher-holliday-on-course": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:15.672Z"
+    "resolvedAt": "2026-03-27T10:36:30.465Z"
   },
   "cd-323-cirque-du-soleil-tapis-rouge": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:35:17.807Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/0a/c1/e4/0ac1e4f1-ff5c-dacb-5375-f9e346d2093b/0874751000059.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:36:31.777Z"
   },
   "cd-324-clarence-williams-the-complete-clarence-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:19.899Z"
+    "resolvedAt": "2026-03-27T10:36:34.539Z"
   },
   "cd-325-claudia-acuna-rhythm-of-life": {
     "url": "https://coverartarchive.org/release/15d5a97c-3279-47b1-9076-1068ff8929fb/43883487287-500.jpg",
@@ -1687,7 +1687,7 @@
   "cd-337-colecao-folha-50-anos-de-bossa-nova-cd-2": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:47.323Z"
+    "resolvedAt": "2026-03-27T10:36:37.318Z"
   },
   "cd-338-coleman-hawkins-body-and-soul": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/cc/c8/92/mzi.bmfudpbr.jpg/600x600bb.jpg",
@@ -1727,7 +1727,7 @@
   "cd-345-chick-corea-colecao-folha-classicos-do-j": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:51.070Z"
+    "resolvedAt": "2026-03-27T10:36:40.035Z"
   },
   "cd-346-corey-harris-henry-butler-vu-du-menz": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/15/da/3c/15da3c15-0167-2049-d682-c25ae59746bb/110497.jpg/600x600bb.jpg",
@@ -1737,12 +1737,12 @@
   "cd-347-alegre-correa-negro-coracao": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:54.102Z"
+    "resolvedAt": "2026-03-27T10:36:42.785Z"
   },
   "cd-348-gal-costa-live-at-the-blue-note-recorded": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:35:55.823Z"
+    "resolvedAt": "2026-03-27T10:36:45.566Z"
   },
   "cd-349-gal-costa-recanto": {
     "url": "https://coverartarchive.org/release/33b8292a-979a-488d-95be-995d6150db4b/43031642281-500.jpg",
@@ -1755,9 +1755,9 @@
     "resolvedAt": "2026-03-26T17:36:01.576Z"
   },
   "cd-351-count-basie-orchestra-basie-s-beatle-bag": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:36:03.971Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/48/67/c7/4867c7f7-94c8-d6c4-0ebc-18f81dbde388/115804.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:36:46.885Z"
   },
   "cd-352-count-basie-orchestra-kansas-city-suit": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/ae/63/81/ae6381a2-60d8-aeeb-34ae-3e04fe64e5f0/190295573843.jpg/600x600bb.jpg",
@@ -1775,9 +1775,9 @@
     "resolvedAt": "2026-03-26T17:36:04.855Z"
   },
   "cd-355-count-basie-joe-williams-the-greatest": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:36:06.836Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/a6/55/0c/a6550cbf-8e40-b493-33e9-72fdd6b894c2/00602537570805.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:36:48.143Z"
   },
   "cd-356-courtney-pine-underground": {
     "url": "http://coverartarchive.org/release/4ea496df-5f42-4b94-9c25-82f29a03123e/2262622578-500.jpg",
@@ -1785,9 +1785,9 @@
     "resolvedAt": "2026-03-26T17:36:11.707Z"
   },
   "cd-357-craig-handy-introducing-three-for-all": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:36:13.980Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f9/34/e6/mzi.kqtflxvx.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:36:49.456Z"
   },
   "cd-358-sheryl-crow-sheryl-crow-and-friends-live": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/fe/70/5a/fe705a1f-a888-b0ba-bbe8-8a4c498cc434/06UMGIM00637.rgb.jpg/600x600bb.jpg",
@@ -1822,7 +1822,7 @@
   "cd-364-curumin-japan-pop-show": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:36:17.646Z"
+    "resolvedAt": "2026-03-27T10:36:52.221Z"
   },
   "cd-365-cyrus-chestnut-blessed-quietness-collect": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/5f/9e/b7/mzi.yeeoahsn.jpg/600x600bb.jpg",
@@ -1857,12 +1857,12 @@
   "cd-371-cyrus-chestnut-william-goffigan": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:36:21.472Z"
+    "resolvedAt": "2026-03-27T10:36:54.960Z"
   },
   "cd-372-daniel-barenboim-tribute-to-ellington": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:36:23.483Z"
+    "resolvedAt": "2026-03-27T10:36:58.477Z"
   },
   "cd-373-danilo-perez-central-avenue": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/f3/43/3f/f3433f87-fb1e-02d8-e7b7-3c92f5bd2fcd/00011105027922.rgb.jpg/600x600bb.jpg",
@@ -1897,7 +1897,7 @@
   "cd-379-dave-burrell-dave-burrell-plays-ellingto": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:36:27.056Z"
+    "resolvedAt": "2026-03-27T10:37:01.280Z"
   },
   "cd-380-dave-douglas-convergence": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/0b/50/6b/mzi.tmebpszr.jpg/600x600bb.jpg",
@@ -1915,9 +1915,9 @@
     "resolvedAt": "2026-03-26T17:36:27.862Z"
   },
   "cd-383-dave-douglass-leap-of-faith": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:36:29.750Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/70/ae/af/70aeaff8-d100-d9b0-c3ca-cbb3596b0cc9/186980000251.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:37:02.637Z"
   },
   "cd-384-david-fathead-newman-chillin": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/07/39/33/073933d6-4fce-6af0-d5c0-61dfe6f5c26e/632375703622_cover.jpg/600x600bb.jpg",
@@ -1987,12 +1987,12 @@
   "cd-397-vinicius-de-moraes-colecao-folha-50-anos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:36:40.684Z"
+    "resolvedAt": "2026-03-27T10:37:05.423Z"
   },
   "cd-398-raul-de-souza-the-other-side-of-the-moon": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:36:42.732Z"
+    "resolvedAt": "2026-03-27T10:37:08.196Z"
   },
   "cd-399-dee-dee-bridgewater-a-tribute-to-horace-": {
     "url": "http://coverartarchive.org/release/3b5d5828-6a85-4cc7-8996-42a1420fd0b4/4488489730-500.jpg",
@@ -2005,9 +2005,9 @@
     "resolvedAt": "2026-03-26T17:36:51.360Z"
   },
   "cd-401-dee-dee-bridgewater-j-ai-deux-amours": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:36:54.680Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/72/fc/52/72fc5276-befc-1eb2-4aa0-c2d326aaad3a/115880.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:37:09.560Z"
   },
   "cd-402-dee-dee-bridgewater-live-at-yoshi-s": {
     "url": "http://coverartarchive.org/release/125ea2f3-db9a-46bf-9a1c-a6461d223fb1/32207353470-500.jpg",
@@ -2030,9 +2030,9 @@
     "resolvedAt": "2026-03-26T17:37:05.828Z"
   },
   "cd-406-cris-delanno-nosso-quintal": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:37:09.290Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/ad/b5/0e/adb50e3a-0a33-796c-a340-23829fb5e62e/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:37:10.901Z"
   },
   "cd-407-delfeayo-marsalis-pontius-pilate-s-decis": {
     "url": "https://coverartarchive.org/release/e1cd86c9-c8d9-49b1-845b-9e8f2d63dbd7/42982122064-500.jpg",
@@ -2072,7 +2072,7 @@
   "cd-414-dexter-gordon-panther-the-tangerine": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:21.717Z"
+    "resolvedAt": "2026-03-27T10:37:14.163Z"
   },
   "cd-415-al-di-meola-al-di-meola": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/04/2b/fd/042bfd1b-fef6-5cf0-370b-e8df67af73e0/mzi.bvwzkmjh.jpg/600x600bb.jpg",
@@ -2147,7 +2147,7 @@
   "cd-429-dick-farney-e-seu-quarteto-dick-farney-j": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:31.315Z"
+    "resolvedAt": "2026-03-27T10:37:16.967Z"
   },
   "cd-430-bo-diddley-i-m-a-man": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/28/33/6e/28336ed8-99ff-5e34-20b6-2533b3781b7a/00602547760715.rgb.jpg/600x600bb.jpg",
@@ -2162,7 +2162,7 @@
   "cd-432-los-diplomaticos-tangos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:33.559Z"
+    "resolvedAt": "2026-03-27T10:37:19.791Z"
   },
   "cd-433-dire-straits-on-every-street": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/d4/6a/41/d46a418d-8fd5-c389-1a4a-c8c9c5c21c10/mzi.gobwatvn.jpg/600x600bb.jpg",
@@ -2177,7 +2177,7 @@
   "cd-435-diversos-duetos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:35.755Z"
+    "resolvedAt": "2026-03-27T10:37:22.677Z"
   },
   "cd-436-divina-caffe-divina-caffe": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ce/5c/d0/mzi.tgsqmwga.jpg/600x600bb.jpg",
@@ -2187,17 +2187,17 @@
   "cd-437-divina-caffe-doisdeuxtwozweiduosduo": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:39.975Z"
+    "resolvedAt": "2026-03-27T10:37:25.471Z"
   },
   "cd-438-dizzy-gillespie-sonny-stitt-kai-winding-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:41.741Z"
+    "resolvedAt": "2026-03-27T10:37:28.232Z"
   },
   "cd-439-dj-dolores-a-maquina-trilha-sonora-do-es": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:37:43.450Z"
+    "resolvedAt": "2026-03-27T10:37:31.463Z"
   },
   "cd-440-dmitri-shostakovich-orchestra-sinfonica-": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/7c/44/d4/mzi.udscmesq.tif/600x600bb.jpg",
@@ -2247,7 +2247,7 @@
   "cd-449-don-byron-and-existential-dred-nu-blaxpl": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:05.920Z"
+    "resolvedAt": "2026-03-27T10:37:35.269Z"
   },
   "cd-450-don-pullen-the-african-brazilian-connect": {
     "url": "https://coverartarchive.org/release/153abe4c-94c2-461a-aec0-272e54c9f9d2/40454783629-500.jpg",
@@ -2267,7 +2267,7 @@
   "cd-453-donald-fagen-walter-becker-old-regime": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:15.991Z"
+    "resolvedAt": "2026-03-27T10:37:38.161Z"
   },
   "cd-454-donald-harrison-free-to-be": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/50/ba/7b/50ba7ba4-7b67-ba9f-8217-d9289c1901de/00011105028325.rgb.jpg/600x600bb.jpg",
@@ -2317,7 +2317,7 @@
   "cd-463-duke-ellington-charlie-mingus-max-roach-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:20.459Z"
+    "resolvedAt": "2026-03-27T10:37:41.198Z"
   },
   "cd-464-duke-ellington-coleman-hawkings-duke-ell": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/d1/ac/85/d1ac85a3-a357-e7ac-d554-5a18b9214398/06UMGIM04310.rgb.jpg/600x600bb.jpg",
@@ -2332,7 +2332,7 @@
   "cd-466-duncan-sheik-steven-sater-claudio-botelh": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:22.684Z"
+    "resolvedAt": "2026-03-27T10:37:44.003Z"
   },
   "cd-467-duofel-duofel": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/3b/bb/5a/3bbb5a79-940d-6872-f09b-ee011f13d725/7899989993600.jpg/600x600bb.jpg",
@@ -2342,7 +2342,7 @@
   "cd-468-dolores-duran-mpb-compositores-dolores-d": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:24.996Z"
+    "resolvedAt": "2026-03-27T10:37:46.703Z"
   },
   "cd-469-orchestre-symphonique-de-montreal-la-mer": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/72/7a/a2/727aa22a-6822-c585-c7ce-026b12eee5eb/12UMGIM09459.rgb.jpg/600x600bb.jpg",
@@ -2367,7 +2367,7 @@
   "cd-473-eastwood-eastwood-after-hours": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:27.692Z"
+    "resolvedAt": "2026-03-27T10:37:49.499Z"
   },
   "cd-474-eddie-daniels-gary-burton-benny-rides-ag": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/15/50/43/15504366-03d8-65b9-4075-918f19f28019/21UMGIM46108.rgb.jpg/600x600bb.jpg",
@@ -2382,7 +2382,7 @@
   "cd-476-mario-edison-trio-uma-noite-no-baretto": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:34.750Z"
+    "resolvedAt": "2026-03-27T10:37:52.264Z"
   },
   "cd-477-eduardo-araujo-po-de-guarana": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music18/v4/b4/85/39/b48539ba-69ee-6efe-b5f1-3a916fc69cce/cover.jpg/600x600bb.jpg",
@@ -2397,7 +2397,7 @@
   "cd-479-eliane-elias-cross-currents": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:38:37.261Z"
+    "resolvedAt": "2026-03-27T10:37:56.203Z"
   },
   "cd-480-eliane-elias-dreamer": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f0/e8/ea/mzi.yvemlmrx.jpg/600x600bb.jpg",
@@ -2455,9 +2455,9 @@
     "resolvedAt": "2026-03-26T17:38:40.118Z"
   },
   "cd-491-eliane-elias-marc-johnson-swept-away": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:38:42.254Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/44/68/c7/4468c7bb-2590-410a-bb70-b4c94ebf1319/00602527945743.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:37:57.545Z"
   },
   "cd-492-ella-fitzgerald-ella-and-louis-again": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/ac/4b/53/ac4b5314-43aa-666b-43b2-845117e9c402/06UMGIM08714.rgb.jpg/600x600bb.jpg",
@@ -2490,9 +2490,9 @@
     "resolvedAt": "2026-03-26T17:38:56.675Z"
   },
   "cd-498-ella-fitzgerald-louis-armstrong-porgy-be": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:38:59.105Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/a9/0f/1a/a90f1a03-880d-4a89-077b-15264cb8ff4b/06UMGIM15223.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:37:59.068Z"
   },
   "cd-499-ella-fitzgerald-louis-armstrong-ella-and": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/ac/4b/53/ac4b5314-43aa-666b-43b2-845117e9c402/06UMGIM08714.rgb.jpg/600x600bb.jpg",
@@ -2522,7 +2522,7 @@
   "cd-504-enrico-pieranunzi-wheeler-potter-haden-m": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:02.399Z"
+    "resolvedAt": "2026-03-27T10:38:01.812Z"
   },
   "cd-505-enya-the-memory-of-trees": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/e6/1d/e6/e61de667-116c-3867-76e2-a9c61696e2f6/mzi.tzpynzpr.jpg/600x600bb.jpg",
@@ -2542,7 +2542,7 @@
   "cd-508-ernie-watts-reaching-up": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:05.109Z"
+    "resolvedAt": "2026-03-27T10:38:04.994Z"
   },
   "cd-509-ernie-watts-unity": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/32/e7/cc/mzi.ctbodctc.tif/600x600bb.jpg",
@@ -2552,12 +2552,12 @@
   "cd-510-estacao-santa-fe-estacao-santa-fe": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:07.292Z"
+    "resolvedAt": "2026-03-27T10:38:07.887Z"
   },
   "cd-511-estrela-leminski-teo-ruiz-tudo-que-n-xc3": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:08.989Z"
+    "resolvedAt": "2026-03-27T10:38:10.768Z"
   },
   "cd-512-etta-james-heart-of-a-woman": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ad/80/79/mzi.xtqxvucq.jpg/600x600bb.jpg",
@@ -2577,12 +2577,12 @@
   "cd-515-eudoxia-de-barros-este-brasil-que-tanto-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:11.470Z"
+    "resolvedAt": "2026-03-27T10:38:14.205Z"
   },
   "cd-516-eudoxia-de-barros-eudoxia-de-barros-inte": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:13.424Z"
+    "resolvedAt": "2026-03-27T10:38:17.252Z"
   },
   "cd-517-eugenia-melo-e-castro-desconstrucao": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/e1/0e/ea/e10eea9f-f0f1-4907-ca6e-c60774994650/25UMGIM50677.rgb.jpg/600x600bb.jpg",
@@ -2637,7 +2637,7 @@
   "cd-527-fagner-pedras-que-cantam": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:22.509Z"
+    "resolvedAt": "2026-03-27T10:38:20.450Z"
   },
   "cd-528-fareed-haque-deja-vu": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/59/56/54/59565435-88c8-e5b1-bdbd-a7374918fca1/00724385241956.jpg/600x600bb.jpg",
@@ -2647,17 +2647,17 @@
   "cd-529-dick-farney-a-arte-do-encontro": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:24.689Z"
+    "resolvedAt": "2026-03-27T10:38:23.357Z"
   },
   "cd-530-dick-farney-dick-farney-piano-orquestra-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:26.603Z"
+    "resolvedAt": "2026-03-27T10:38:26.195Z"
   },
   "cd-531-dick-farney-meus-momentos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:28.588Z"
+    "resolvedAt": "2026-03-27T10:38:29.252Z"
   },
   "cd-532-fat-family-fat-family": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/4c/5d/31/4c5d3166-3a4b-fb3c-473e-1776ff947466/13DMGIM04437.rgb.jpg/600x600bb.jpg",
@@ -2692,7 +2692,7 @@
   "cd-538-fernando-joao-aguarelas-na-noite": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:31.715Z"
+    "resolvedAt": "2026-03-27T10:38:32.198Z"
   },
   "cd-539-rachelle-ferrell-rachelle-ferrell": {
     "url": "https://coverartarchive.org/release/b1d02059-8346-4ef6-b4ac-00da6a1defaf/6658185839-500.jpg",
@@ -2712,7 +2712,7 @@
   "cd-542-geraldo-flasch-piano": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:42.735Z"
+    "resolvedAt": "2026-03-27T10:38:35.054Z"
   },
   "cd-543-fleetwood-mac-live-at-the-marquee": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/0c/73/fc/0c73fcc7-0d61-d994-af89-2909a39ea097/mzi.bfzyhzca.jpg/600x600bb.jpg",
@@ -2727,12 +2727,12 @@
   "cd-545-fluencia-a-moradia-do-som": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:44.954Z"
+    "resolvedAt": "2026-03-27T10:38:37.828Z"
   },
   "cd-546-focus-hocus-pocus-the-best-of-focus": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:39:46.845Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/bd/33/59/bd3359f3-c4af-e7d3-0ada-4942d4bfadf8/8712944086256.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:38:39.212Z"
   },
   "cd-547-four-80-east-the-album": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/ee/d1/da/eed1da86-9e2f-a19b-498a-f03622b183b2/00854242007569.rgb.jpg/600x600bb.jpg",
@@ -2752,7 +2752,7 @@
   "cd-550-franci-symphony-of-my-dreams": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:49.284Z"
+    "resolvedAt": "2026-03-27T10:38:41.967Z"
   },
   "cd-551-francisco-alves-in-memoriam": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/7a/f5/a0/mzi.fqmyfsbs.jpg/600x600bb.jpg",
@@ -2787,7 +2787,7 @@
   "cd-557-frank-sinatra-grandes-momentos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:52.619Z"
+    "resolvedAt": "2026-03-27T10:38:44.794Z"
   },
   "cd-558-frank-sinatra-royal-festival-hall": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/a4/66/6a/a4666aad-a2f9-1fc4-d0eb-b6e0ec6dcdb0/00724353374051.jpg/600x600bb.jpg",
@@ -2802,17 +2802,17 @@
   "cd-560-frank-sinatra-the-voice-of-frank-sinatra": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:54.799Z"
+    "resolvedAt": "2026-03-27T10:38:47.575Z"
   },
   "cd-561-frank-sinatra-the-voice-of-frank-sinatra": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:56.540Z"
+    "resolvedAt": "2026-03-27T10:38:50.309Z"
   },
   "cd-562-frank-sinatra-the-voice-of-frank-sinatra": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:39:58.512Z"
+    "resolvedAt": "2026-03-27T10:38:53.092Z"
   },
   "cd-563-frank-sinatra-count-basie-it-might-as-we": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/64/b3/79/64b379dc-73ea-da06-c2d8-a6c06ec42d18/15UMGIM08561.rgb.jpg/600x600bb.jpg",
@@ -2897,7 +2897,7 @@
   "cd-579-carlos-gardel-as-grandes-interpretacoes-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:40:09.842Z"
+    "resolvedAt": "2026-03-27T10:38:55.892Z"
   },
   "cd-580-carlos-gardel-carlos-gardel": {
     "url": "http://coverartarchive.org/release/a9066322-9032-4a09-a8bb-d52017b32221/9406406594-500.jpg",
@@ -2912,7 +2912,7 @@
   "cd-582-carlos-gardel-the-essential-of": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:40:16.914Z"
+    "resolvedAt": "2026-03-27T10:38:58.750Z"
   },
   "cd-583-gary-burton-like-minds": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/a7/6c/e3/a76ce377-35f4-2c89-73cc-7f5c9b4a8502/00013431480327.rgb.jpg/600x600bb.jpg",
@@ -2920,9 +2920,9 @@
     "resolvedAt": "2026-03-26T17:40:17.160Z"
   },
   "cd-584-paulah-gauss-vou-livre": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:40:19.382Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/09/78/ee/0978ee50-9cec-b463-fcf5-facf148c2639/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:00.168Z"
   },
   "cd-585-marvin-gaye-what-s-going-on": {
     "url": "http://coverartarchive.org/release/2149d653-fd66-4f05-b6de-9b8fd8e98537/21129363393-500.jpg",
@@ -2930,9 +2930,9 @@
     "resolvedAt": "2026-03-26T17:40:23.735Z"
   },
   "cd-586-gene-harris-trio-plus-one-gene-harris-tr": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:40:25.919Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/f7/31/48/f73148dd-6bc2-39c3-d81e-3bbb73c72ffd/00013431430322.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:01.489Z"
   },
   "cd-587-genesis-we-can-t-dance": {
     "url": "http://coverartarchive.org/release/30f13c4a-897f-403a-ba7e-f597d7cf62fc/15465580202-500.jpg",
@@ -2982,7 +2982,7 @@
   "cd-596-geri-allen-eyes-in-the-back-of-your-head": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:40:50.061Z"
+    "resolvedAt": "2026-03-27T10:39:05.405Z"
   },
   "cd-597-geri-allen-live-at-the-village-vanguard": {
     "url": "http://coverartarchive.org/release/5df76f50-391f-4e26-be45-cee89a328239/37709417502-500.jpg",
@@ -3000,9 +3000,9 @@
     "resolvedAt": "2026-03-26T17:41:03.362Z"
   },
   "cd-600-geri-allen-the-gathering": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:05.558Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/bb/d8/37/bbd83785-9502-75c1-d51f-1624bff2db63/00731455761429.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:06.698Z"
   },
   "cd-601-geri-allen-trio-twenty-one": {
     "url": "https://coverartarchive.org/release/c614cb79-b140-4fe7-b832-a6ee8173579e/33354154218-500.jpg",
@@ -3025,44 +3025,44 @@
     "resolvedAt": "2026-03-26T17:41:22.546Z"
   },
   "cd-605-gerry-mulligan-quartet-the-best-of-gerry": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:24.478Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/70/e2/16/70e21660-4915-a01f-b1da-a6410bf73290/00077779548156.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:08.010Z"
   },
   "cd-606-gerry-mulligan-chet-baker-carnegie-hall-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:26.423Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/c0/0b/65/mzi.bpqhqwix.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:09.379Z"
   },
   "cd-607-beniamino-gigli-o-sole-mio-the-very-best": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:28.359Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/4e/f6/be/mzi.ptukagyh.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:10.763Z"
   },
   "cd-608-beniamino-gigli-mamma": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:30.267Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/3a/e8/9f/3ae89fba-8671-1dc2-4419-50a3a6c401fe/886448559085.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:12.088Z"
   },
   "cd-609-beniamino-gigli-popular-songs-o-sole-mio": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:32.189Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/4e/f6/be/mzi.ptukagyh.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:13.404Z"
   },
   "cd-610-gil-evans-great-jazz-standards": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:35.045Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/62/2f/1b/622f1b6e-5328-7326-5c93-58688f502674/23UMGIM26489.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:14.669Z"
   },
   "cd-611-gil-evans-sting-strange-fruit": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:41:36.985Z"
+    "resolvedAt": "2026-03-27T10:39:17.396Z"
   },
   "cd-612-gilberto-gil-concerto-de-cordas-maquinas": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:41:39.139Z"
+    "resolvedAt": "2026-03-27T10:39:21.588Z"
   },
   "cd-613-gilberto-gil-gil-luminoso": {
     "url": "http://coverartarchive.org/release/ddb63f13-b0a8-4bf4-b9c7-4eba0564f89a/35068102266-500.jpg",
@@ -3080,14 +3080,14 @@
     "resolvedAt": "2026-03-26T17:41:54.543Z"
   },
   "cd-616-gilberto-gil-jorge-ben-gil-e-jorge": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:56.747Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/77/98/66/77986692-10ed-fefc-5eb2-18b4c0e7e6b3/21UM1IM56290.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:22.944Z"
   },
   "cd-617-gilberto-gil-milton-nascimento-gil-milto": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:41:58.729Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/f9/1f/c6/f91fc642-1f4f-1575-2c13-64b56e8a470e/190296714528.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:24.278Z"
   },
   "cd-618-astrud-gilberto-jazz-round-midnight": {
     "url": "http://coverartarchive.org/release/a07aae5c-2b97-445b-925a-1d386f4617be/37100243300-500.jpg",
@@ -3110,14 +3110,14 @@
     "resolvedAt": "2026-03-26T17:42:15.485Z"
   },
   "cd-622-dizzy-gillespie-dizzy-gillespie": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:42:17.686Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/9c/3b/76/9c3b76cd-4992-8724-af81-012431a595c6/00602567828938.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:25.597Z"
   },
   "cd-623-ginger-baker-going-back-home": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:42:19.835Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/75/35/63/75356374-f72e-4ad9-c67d-b76020a07ab9/mzi.zhxmpbsj.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:26.985Z"
   },
   "cd-624-egberto-gismonti-antologia": {
     "url": "https://coverartarchive.org/release/e29301fc-8b5a-4f13-99e0-15a2ff019647/38740076368-500.jpg",
@@ -3125,9 +3125,9 @@
     "resolvedAt": "2026-03-26T17:42:24.735Z"
   },
   "cd-625-glory-crampton-unusual-way": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:42:26.927Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/c3/1b/92/c31b92d4-20b7-2c11-07c3-3fac470dc1c0/605288141829.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:28.240Z"
   },
   "cd-626-gonzalo-rubalcaba-discovery-live-at-mont": {
     "url": "http://coverartarchive.org/release/acfd0efc-7091-453b-8708-7525aaa8dfc7/16244141797-500.jpg",
@@ -3142,12 +3142,12 @@
   "cd-628-gonzalo-rubalcaba-giraldilla": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:42:37.962Z"
+    "resolvedAt": "2026-03-27T10:39:30.994Z"
   },
   "cd-629-gonzalo-rubalcaba-images-live-from-mt-fu": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:42:39.910Z"
+    "resolvedAt": "2026-03-27T10:39:34.049Z"
   },
   "cd-630-gonzalo-rubalcaba-inner-voyage": {
     "url": "http://coverartarchive.org/release/d751a09f-dcdf-4458-9888-6f606660fb48/4478719144-500.jpg",
@@ -3160,19 +3160,19 @@
     "resolvedAt": "2026-03-26T17:42:51.556Z"
   },
   "cd-632-gonzalo-rubalcaba-suite-4-y-20": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:42:53.888Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/a6/2e/7f/a62e7fb0-5156-952b-03b8-ade41385e09d/00044001361128.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:35.402Z"
   },
   "cd-633-goo-goo-dolls-dizzy-up-the-girl": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:42:56.088Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2c/13/18/2c131801-00af-58b1-3cc2-13abf4ad5416/093624919162.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:36.658Z"
   },
   "cd-634-benny-goodman-benny-goodman": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:42:58.255Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music2/v4/ff/8c/f7/ff8cf7bb-0ad9-8bad-90b9-7f6526cc7b24/0887158135132_cover.tif/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:37.996Z"
   },
   "cd-635-gotan-project-la-revancha-del-tango": {
     "url": "http://coverartarchive.org/release/88d7145f-732c-38f2-8bc9-31f2e81259eb/9845751214-500.jpg",
@@ -3180,9 +3180,9 @@
     "resolvedAt": "2026-03-26T17:43:02.621Z"
   },
   "cd-636-grand-funk-railroad-closer-to-home": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:43:04.991Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/97/da/03/97da039c-4e40-50aa-132c-798e38ab0822/00724353938055.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:39.244Z"
   },
   "cd-637-grand-funk-railroad-live-album": {
     "url": "https://coverartarchive.org/release/5a107c93-9ef9-36cd-a535-dab98c863671/41682000559-500.jpg",
@@ -3215,9 +3215,9 @@
     "resolvedAt": "2026-03-26T17:43:33.903Z"
   },
   "cd-643-al-green-al-green-is-love": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:43:36.641Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/33/9c/32/339c3286-4a49-a146-e17a-32e91cc8a023/886446395760.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:40.500Z"
   },
   "cd-644-al-green-don-t-look-back": {
     "url": "http://coverartarchive.org/release/67062d9b-bf9e-4e9c-be5a-7da96c2b5af1/37615740443-500.jpg",
@@ -3225,9 +3225,9 @@
     "resolvedAt": "2026-03-26T17:43:41.654Z"
   },
   "cd-645-al-green-he-is-the-light": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:43:43.896Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/7c/2b/c5/7c2bc54b-c881-a6f2-ed7c-b6ad8610b639/00731452032720.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:41.820Z"
   },
   "cd-646-al-green-let-s-stay-together": {
     "url": "http://coverartarchive.org/release/ca27e0fa-3aba-4bf2-bb73-2ea44d8bdf90/16773802184-500.jpg",
@@ -3250,14 +3250,14 @@
     "resolvedAt": "2026-03-26T17:44:06.453Z"
   },
   "cd-650-gregorio-barrios-gregorio-barrios": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:08.318Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/df/3f/6c/df3f6c09-fc02-b191-0d7d-215c9470c947/8447098844574.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:43.103Z"
   },
   "cd-651-gregorio-barrios-toda-una-vida-vol4": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:44:10.154Z"
+    "resolvedAt": "2026-03-27T10:39:45.872Z"
   },
   "cd-652-josh-groban-josh-groban": {
     "url": "http://coverartarchive.org/release/316ec04e-5353-4205-b6a5-a28ce9f8316e/12999884971-500.jpg",
@@ -3270,64 +3270,64 @@
     "resolvedAt": "2026-03-26T17:44:19.380Z"
   },
   "cd-654-grp-all-star-big-band-grp-all-star-big-b": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:21.537Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/fe/69/eb/fe69eb42-30fc-6230-37a6-f2ad6a2a737e/00011105967228.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:47.225Z"
   },
   "cd-655-grupo-zamanakitoki-kaya-grandi": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:44:23.384Z"
+    "resolvedAt": "2026-03-27T10:39:49.985Z"
   },
   "cd-656-guga-stroeter-orquestra-hb-baile-dos-ori": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:25.299Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/7f/96/3c/7f963cb8-fa55-b47b-d6da-751a4680a38e/0732535842083.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:51.340Z"
   },
   "cd-657-guga-stroeter-orquestra-hb-e-samba-berer": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:44:27.273Z"
+    "resolvedAt": "2026-03-27T10:39:54.060Z"
   },
   "cd-658-guga-stroeter-orquestra-hb-xire-reverb": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:44:29.726Z"
+    "resolvedAt": "2026-03-27T10:39:56.920Z"
   },
   "cd-659-guga-stroeter-hb-jazz-combo-duke-sao-pau": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:31.652Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f8/48/e0/mzi.cxftzzye.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:58.323Z"
   },
   "cd-660-guga-stroeter-hb-jazz-combo-liena-centen": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:33.608Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/72/dd/15/mzi.rvvqznao.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:39:59.600Z"
   },
   "cd-661-guga-stroeter-orquestra-hb-dora-stroeter": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:44:35.611Z"
+    "resolvedAt": "2026-03-27T10:40:02.323Z"
   },
   "cd-662-guga-stroeter-orquestra-hb-sapopemba-sap": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:37.449Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/c4/8c/c9/mzi.tdglohqw.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:03.638Z"
   },
   "cd-663-guga-stroeter-orquestra-heartbreakers-em": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:44:39.305Z"
+    "resolvedAt": "2026-03-27T10:40:06.519Z"
   },
   "cd-664-flavio-guimaraes-little-blues": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:42.322Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/88/53/b4/8853b4b6-bdef-5d9d-bfbc-18bb58a9763a/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:07.808Z"
   },
   "cd-665-guinga-cheio-de-dedos": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:44.524Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/f0/95/21/f095214c-e532-e6bb-e376-477c0968be76/dj.olfveuds.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:09.064Z"
   },
   "cd-666-guinga-delirio-carioca": {
     "url": "http://coverartarchive.org/release/c94cedce-8c81-41cd-b60d-7f415891aca8/21573179698-500.jpg",
@@ -3335,19 +3335,19 @@
     "resolvedAt": "2026-03-26T17:44:50.608Z"
   },
   "cd-667-guinga-suite-leopoldina": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:53.019Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music3/v4/c5/18/60/c518608f-9162-8eff-16a4-85593a1bd525/dj.xcfchoso.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:10.381Z"
   },
   "cd-668-guinga-aldir-blanc-simples-e-absurdo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:55.052Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/c0/6d/3b/c06d3bc9-fbee-e246-bc0d-722f72085561/0632627917524.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:11.740Z"
   },
   "cd-669-guinga-quinteto-villa-lobos-rasgando-sed": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:44:57.123Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/ab/8d/3a/ab8d3a34-336e-928b-4895-93bd00ff23ce/7898444700708.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:12.974Z"
   },
   "cd-670-guns-n-roses-live-era-87-93": {
     "url": "https://coverartarchive.org/release/e1562c2b-adf3-4d71-a140-c3f46e6fdc33/5685959079-500.jpg",
@@ -3355,9 +3355,9 @@
     "resolvedAt": "2026-03-26T17:45:01.758Z"
   },
   "cd-671-guru-jazzmatazz-volume-1": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:45:04.033Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/20/8a/1c/208a1c15-f7fd-1cb2-f214-c6d17370da44/00094632199850.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:14.272Z"
   },
   "cd-672-guru-jazzmatazz-volume-2-the-new-reality": {
     "url": "http://coverartarchive.org/release/9c51fcb3-631c-4966-bdc0-7cff28c549c9/37074372974-500.jpg",
@@ -3382,17 +3382,17 @@
   "cd-676-harold-jones-live-at-the-1990-concord-ja": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:45:26.700Z"
+    "resolvedAt": "2026-03-27T10:40:16.977Z"
   },
   "cd-677-harry-connick-jr-blue-light": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:45:29.074Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features125/v4/c5/9b/e2/c59be2c8-2851-c165-1c18-449cc0629b1e/dj.iltmwzmj.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:18.625Z"
   },
   "cd-678-harry-connick-jr-come-by-me": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:45:31.471Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/10/ed/e3/mzi.gvbeyjxp.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:19.862Z"
   },
   "cd-679-harry-connick-jr-when-harry-met-sally": {
     "url": "http://coverartarchive.org/release/b2ad26c7-0d95-4cbe-b802-8244999c9c28/19423096503-500.jpg",
@@ -3412,17 +3412,17 @@
   "cd-682-heartbreakers-salsa-brasileira": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:45:51.338Z"
+    "resolvedAt": "2026-03-27T10:40:22.616Z"
   },
   "cd-683-helen-merrill-gitanes-jazz": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:45:53.267Z"
+    "resolvedAt": "2026-03-27T10:40:25.374Z"
   },
   "cd-684-helen-merrill-jelena-ana-milcetic-a-k-a-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:45:55.215Z"
+    "resolvedAt": "2026-03-27T10:40:28.436Z"
   },
   "cd-685-fletcher-henderson-a-study-in-frustratio": {
     "url": "https://coverartarchive.org/release/6be47e44-ea5f-4788-a22e-8c8b08c13fe6/39603868671-500.jpg",
@@ -3445,9 +3445,9 @@
     "resolvedAt": "2026-03-26T17:46:13.913Z"
   },
   "cd-689-herbie-hancock-gershwin-s-world": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:16.426Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/84/05/68/8405683a-4b4c-2f53-f7cd-a371ecb9b981/00602547331359.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:29.795Z"
   },
   "cd-690-herbie-hancock-quartet": {
     "url": "http://coverartarchive.org/release/520d4a3e-2980-3b35-83f7-5dcea02a39fd/12283848867-500.jpg",
@@ -3455,24 +3455,24 @@
     "resolvedAt": "2026-03-26T17:46:20.787Z"
   },
   "cd-691-herbie-hancock-the-new-standard": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:23.094Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/27/13/98/2713982b-697c-3541-c309-1cf5648905c0/06UMGIM41957.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:31.030Z"
   },
   "cd-692-herbie-hancock-v-s-o-p-quintet": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:46:24.972Z"
+    "resolvedAt": "2026-03-27T10:40:33.877Z"
   },
   "cd-693-herbie-hancock-and-others-a-tribute-to-m": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:27.058Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/37/b3/bb/37b3bb0d-ac5d-ea89-071a-cdef9a3a3168/mzi.yecrffda.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:35.152Z"
   },
   "cd-694-herbie-hancock-michael-brecker-roy-hargr": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:29.026Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/a3/4e/32/a34e323e-99ca-13c6-d0d8-f5a75dd90620/00602547308771.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:36.469Z"
   },
   "cd-695-herman-s-hermits-no-milk-today": {
     "url": "http://coverartarchive.org/release/754af1eb-0384-4c7d-bd23-67b55a3dfd4e/33168305747-500.jpg",
@@ -3480,29 +3480,29 @@
     "resolvedAt": "2026-03-26T17:46:34.330Z"
   },
   "cd-696-hoagy-carmichael-hoagy-sings-carmichael": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:36.697Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/55/1f/9f/551f9fca-d95a-c583-0535-40c26274dc0d/00077774686259.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:37.710Z"
   },
   "cd-697-billie-holiday-billie-holiday": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:39.035Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/69/65/ed/6965ed9b-32bd-6366-a462-d2b6ec83db78/15UMGIM13908.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:39.139Z"
   },
   "cd-698-holly-cole-dark-dear-heart": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:41.161Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/70/39/85/7039851d-0150-aaa5-84fc-89a7f92a7ae0/00724385736551.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:40.444Z"
   },
   "cd-699-homens-do-brasil-cd-promocional": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:46:43.200Z"
+    "resolvedAt": "2026-03-27T10:40:43.582Z"
   },
   "cd-700-homens-do-brasil-homens-do-brasil": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:46:45.184Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/d5/3f/62/d53f62e7-1cbc-2817-dac9-a90c4369a3f4/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:44.914Z"
   },
   "cd-701-horace-silver-a-prescription-for-the-blu": {
     "url": "http://coverartarchive.org/release/cc064fd3-fe52-4130-8ec3-55771326a245/7569227042-500.jpg",
@@ -3512,7 +3512,7 @@
   "cd-702-horace-silver-colecao-folha-classicos-do": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:46:52.585Z"
+    "resolvedAt": "2026-03-27T10:40:47.653Z"
   },
   "cd-703-horace-silver-horace-silver-and-the-jazz": {
     "url": "https://coverartarchive.org/release/9ad56baa-8590-47e9-a3d8-a3b60fbff8f2/34460933626-500.jpg",
@@ -3540,14 +3540,14 @@
     "resolvedAt": "2026-03-26T17:47:17.307Z"
   },
   "cd-708-howard-johnson-gravity-gravity": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:47:19.428Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/de/4d/76/de4d7640-2d13-ee9f-02e9-2261352fed92/00731453102125.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:48.959Z"
   },
   "cd-709-hunter-charlie-baboon-strength": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:47:21.482Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/69/ba/8c/69ba8c52-34c2-6b39-ae45-355bc4b5fbdd/197188321703.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:50.317Z"
   },
   "cd-710-julio-iglesias-tango": {
     "url": "https://coverartarchive.org/release/d732fc19-c717-4c27-9ffd-31f71410a28b/26711692744-500.jpg",
@@ -3562,7 +3562,7 @@
   "cd-712-os-insistentes-primeiros-erros": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:47:33.194Z"
+    "resolvedAt": "2026-03-27T10:40:53.107Z"
   },
   "cd-713-irene-reid-million-dollar-secret": {
     "url": "http://coverartarchive.org/release/b9e75305-6038-49ef-a9b0-7dce839412cb/25531294837-500.jpg",
@@ -3585,24 +3585,24 @@
     "resolvedAt": "2026-03-26T17:47:49.738Z"
   },
   "cd-717-itibere-orquestra-familia-pedra-do-espia": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:47:52.146Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/98/fa/c0/98fac0c9-6a36-6e2c-ae28-d791add67148/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:54.355Z"
   },
   "cd-718-ivo-perelman-ivo-perelman": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:47:54.053Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/6a/45/02/6a450222-a649-f10b-614c-6df236348977/4062548004267_3000.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:55.768Z"
   },
   "cd-719-izzy-o-que-tenho-pra-dizer": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:47:55.975Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f2/5f/e5/mzi.cpdelcvw.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:57.039Z"
   },
   "cd-720-jack-dejohnette-parallel-realities": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:47:58.177Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/2c/eb/6e/2ceb6e39-6d9a-39bf-31ca-a10053e4bb09/00076742231323.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:58.429Z"
   },
   "cd-721-jack-mcduff-groovin": {
     "url": "http://coverartarchive.org/release/59dceee8-535e-4d08-9907-13b3182e59e1/16543250378-500.jpg",
@@ -3630,9 +3630,9 @@
     "resolvedAt": "2026-03-26T17:48:19.356Z"
   },
   "cd-726-michael-jackson-thriller-25": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:48:21.476Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/32/4f/fd/324ffda2-9e51-8f6a-0c2d-c6fd2b41ac55/074643811224.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:40:59.680Z"
   },
   "cd-727-jacky-terrasson-alive": {
     "url": "http://coverartarchive.org/release/7c47cfec-c6b2-4723-8ee7-1d6649b9fbb8/7848428422-500.jpg",
@@ -3645,9 +3645,9 @@
     "resolvedAt": "2026-03-26T17:48:30.199Z"
   },
   "cd-729-jacky-terrasson-reach": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:48:32.393Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/40/e7/40/40e7409c-df82-3bd0-1a7b-fc14c5996ab4/00724383757053.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:01.348Z"
   },
   "cd-730-jacky-terrasson-what-it-is": {
     "url": "https://coverartarchive.org/release/55772a59-f6ff-42ba-9394-4c55ea91a82b/41324377804-500.jpg",
@@ -3655,14 +3655,14 @@
     "resolvedAt": "2026-03-26T17:48:37.119Z"
   },
   "cd-731-jacky-terrasson-cassandra-wilson-rendezv": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:48:39.219Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/a0/dd/f4/a0ddf478-86a0-23aa-609f-502c9d78cbbd/00724385548451.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:02.654Z"
   },
   "cd-732-jaco-pastorius-live-in-new-york-city-vol": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:48:41.487Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music7/v4/c7/5a/4c/c75a4c2c-7a62-6143-4e6f-2995b51e9d03/889326473480_Cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:03.967Z"
   },
   "cd-733-jaco-pastorius-live-in-new-york-city-vol": {
     "url": "http://coverartarchive.org/release/df6cc90d-2341-4726-8dbd-e77126ef0075/34020749099-500.jpg",
@@ -3682,17 +3682,17 @@
   "cd-736-jahre-hubner-running-wild": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:48:56.798Z"
+    "resolvedAt": "2026-03-27T10:41:07.450Z"
   },
   "cd-737-jamelao-mestres-da-mpb": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:48:58.771Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/87/ef/a8/87efa86d-bdd6-f9e6-ad28-2f3390e74cfd/745099596163.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:08.764Z"
   },
   "cd-738-james-carter-chasin-the-gypsy": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:00.880Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/7e/3d/7d/mzi.mjnqtpya.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:10.210Z"
   },
   "cd-739-james-carter-conversin-with-the-elders": {
     "url": "https://coverartarchive.org/release/79b63475-dc2d-4c4d-b2bb-c2729f46c95e/39084965614-500.jpg",
@@ -3700,24 +3700,24 @@
     "resolvedAt": "2026-03-26T17:49:07.232Z"
   },
   "cd-740-james-carter-in-carterian-fashion": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:09.826Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/e1/93/8b/mzi.lnjdildj.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:11.445Z"
   },
   "cd-741-james-carter-jc-on-the-set": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:15.431Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/f5/64/7a/f5647ae7-261b-66ca-2652-d24bb18840f2/886449823635.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:13.914Z"
   },
   "cd-742-james-carter-jurassic-classics": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:17.756Z"
+    "url": "http://coverartarchive.org/release/3874e929-cc29-4834-b72f-8c09e983ac1a/15539790722-500.jpg",
+    "source": "coverart",
+    "resolvedAt": "2026-03-27T10:41:20.754Z"
   },
   "cd-743-james-carter-layin-in-the-cut": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:19.975Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/37/25/72/mzi.fpzxbdzo.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:22.279Z"
   },
   "cd-744-james-carter-the-real-quietstorm": {
     "url": "http://coverartarchive.org/release/70ec9e9b-0f6a-41bb-ae03-b4b93d27cd43/28978151237-500.jpg",
@@ -3725,9 +3725,9 @@
     "resolvedAt": "2026-03-26T17:49:24.431Z"
   },
   "cd-745-james-moody-moody-plays-mancini": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:26.776Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/11/6b/5e/mzi.xurgghrg.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:23.526Z"
   },
   "cd-746-jamiroquai-synkronized": {
     "url": "http://coverartarchive.org/release/68f52c38-702e-3ebd-9b08-9a2d651de602/2981543235-500.jpg",
@@ -3735,14 +3735,14 @@
     "resolvedAt": "2026-03-26T17:49:31.001Z"
   },
   "cd-747-jan-garbarek-miroslav-vitous-peter-erski": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:33.273Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/6a/b5/4d/6ab54ddf-7a2a-a1c9-0b01-ee1e146e3161/00042284964920.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:24.943Z"
   },
   "cd-748-jane-ira-bloom-the-red-quarters": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:35.123Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features4/v4/5a/ca/40/5aca40ca-1e49-a303-62cb-28db0ce42334/dj.jmokgmtc.tif/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:26.192Z"
   },
   "cd-749-jane-monheit-come-dream-with-me": {
     "url": "http://coverartarchive.org/release/5b288cf9-8251-4af0-be3c-6cbdd457dd46/14187051382-500.jpg",
@@ -3765,9 +3765,9 @@
     "resolvedAt": "2026-03-26T17:49:52.717Z"
   },
   "cd-753-javon-jackson-for-one-who-knows": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:49:54.898Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/64/22/0f/64220fe1-9016-c2e6-1215-38effb982d51/13UABIM07171.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:27.497Z"
   },
   "cd-754-javon-jackson-good-people": {
     "url": "https://coverartarchive.org/release/fbb18b22-bf9e-4674-9ab1-67c84e8874f4/43707581787-500.jpg",
@@ -3775,9 +3775,9 @@
     "resolvedAt": "2026-03-26T17:49:59.577Z"
   },
   "cd-755-jeanie-bryson-sings-songs-of-peggy-lee-s": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:01.846Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/8a/6b/1d/8a6b1d62-2615-deea-9fac-2f42d40b6edd/22CRGIM34805.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:28.768Z"
   },
   "cd-756-jeff-tain-watts-citizen-tain": {
     "url": "http://coverartarchive.org/release/437d0446-6d16-4652-a2c2-2a2f4eeaa4b0/20414391037-500.jpg",
@@ -3787,7 +3787,7 @@
   "cd-757-jeremy-steig-jigsaw": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:50:10.531Z"
+    "resolvedAt": "2026-03-27T10:41:33.170Z"
   },
   "cd-758-jeri-brown-april-in-paris": {
     "url": "http://coverartarchive.org/release/17240b57-1165-403b-9dc3-eed975de595b/13543965204-500.jpg",
@@ -3800,39 +3800,39 @@
     "resolvedAt": "2026-03-26T17:50:20.150Z"
   },
   "cd-760-jeri-brown-zaius": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:22.478Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/f0/fe/d2/f0fed274-5190-cdf9-0e5c-64f40c08ac3a/068944011759.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:34.497Z"
   },
   "cd-761-jerry-michelsen-jerry-michelsen": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:24.635Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/5b/71/7d/5b717d29-b658-a066-ca2f-0062409edda6/887516132162.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:35.862Z"
   },
   "cd-762-jesse-harris-star-rover-no-wrong-no-righ": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:50:26.581Z"
+    "resolvedAt": "2026-03-27T10:41:38.588Z"
   },
   "cd-763-jessica-williams-encounters-vol-2": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:50:28.547Z"
+    "resolvedAt": "2026-03-27T10:41:41.664Z"
   },
   "cd-764-jessica-williams-momentum": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:50:30.430Z"
+    "resolvedAt": "2026-03-27T10:41:44.578Z"
   },
   "cd-765-jessica-williams-trio-and-then-there-s-t": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:50:32.273Z"
+    "resolvedAt": "2026-03-27T10:41:47.340Z"
   },
   "cd-766-jethro-tull-aqualung": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:34.409Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music7/v4/09/a8/a1/09a8a1ba-c977-e1f2-2be4-d6e8b4b040f8/825646111596.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:48.570Z"
   },
   "cd-767-jethro-tull-minstrel-in-the-gallery": {
     "url": "http://coverartarchive.org/release/eb364366-c64b-4665-a9c4-f14446e7cec7/9942771780-500.jpg",
@@ -3840,9 +3840,9 @@
     "resolvedAt": "2026-03-26T17:50:40.218Z"
   },
   "cd-768-jethro-tull-original-masters": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:42.593Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/54/e9/a4/54e9a434-4c25-e711-176c-6edb9a26e31e/825646035502.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:49.887Z"
   },
   "cd-769-jill-scott-collaborations": {
     "url": "http://coverartarchive.org/release/624a0689-1bb8-4874-8aeb-acc7b2b4f0ba/29142876510-500.jpg",
@@ -3850,29 +3850,29 @@
     "resolvedAt": "2026-03-26T17:50:47.244Z"
   },
   "cd-770-jim-hall-dialogues": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:49.567Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/d1/49/54/d1495434-0499-78c8-96ee-e7fafeee6f0a/23CRGIM36443.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:51.125Z"
   },
   "cd-771-jim-hall-pat-metheny-jim-hall-pat-methen": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:54.275Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/f9/e9/51/f9e951bd-4e29-cc3e-1904-ff55be5da94d/075597990959_Cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:52.385Z"
   },
   "cd-772-jimmy-giuffre-trio-carla": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:50:56.411Z"
+    "resolvedAt": "2026-03-27T10:41:55.205Z"
   },
   "cd-773-jimmy-giuffre-paul-bley-steve-swallow-co": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:50:58.310Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/5f/34/b7/5f34b78d-f847-a312-cb25-57b2d8d323a0/mzi.eqrxrcoa.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:56.465Z"
   },
   "cd-774-jimmy-scott-dream": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:51:00.484Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/99/bc/d7/mzi.xeqqoblb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:57.728Z"
   },
   "cd-775-jimmy-smith-damn": {
     "url": "http://coverartarchive.org/release/859cc7f4-4817-4d93-b2e2-038afa9859ec/22456917926-500.jpg",
@@ -3895,14 +3895,14 @@
     "resolvedAt": "2026-03-26T17:51:18.249Z"
   },
   "cd-779-joao-parahyba-o-samba-no-balanco-do-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:51:20.345Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/9f/66/7b/9f667bfd-2fbe-01d3-80d3-1fe97ba2a3fc/7898444700555.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:41:59.049Z"
   },
   "cd-780-tom-jobim-colecao-folha-50-anos-bossa-no": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:51:22.202Z"
+    "resolvedAt": "2026-03-27T10:42:01.790Z"
   },
   "cd-781-joe-henderson-big-band": {
     "url": "http://coverartarchive.org/release/be117769-7661-4e69-a1ca-3279809d417b/16342507436-500.jpg",
@@ -3925,14 +3925,14 @@
     "resolvedAt": "2026-03-26T17:51:39.447Z"
   },
   "cd-785-joe-henderson-the-state-of-the-tenor": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:51:41.676Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/1d/69/18/1d691811-d935-3b72-9f1d-3cf23c9734af/00724382887959.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:03.048Z"
   },
   "cd-786-joe-henderson-the-wynton-kelly-trio-four": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:51:43.579Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/81/ee/b0/81eeb047-e9cb-4c62-42db-70a6ff9e7d9a/00731452365729.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:04.440Z"
   },
   "cd-787-joe-lovano-52nd-street-themes": {
     "url": "http://coverartarchive.org/release/7db2da08-1791-4496-b44a-7e7e3e7fa108/16415091869-500.jpg",
@@ -3960,29 +3960,29 @@
     "resolvedAt": "2026-03-26T17:52:08.028Z"
   },
   "cd-792-joe-lovano-worlds": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:10.478Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/77/38/42/7738422d-7491-b032-dd4c-784d96fdadb0/186980000848.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:06.261Z"
   },
   "cd-793-joe-lovano-gonzalo-rubalcaba-flying-colo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:12.427Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/d4/fe/e3/d4fee3f0-0ca2-9c0e-9f73-47a8fc4b309f/00094633456655.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:07.547Z"
   },
   "cd-794-joe-lovano-greg-osby-friendly-fire": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:14.285Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/6c/94/84/6c94842d-822b-ec01-715f-3c84d3bd8d3b/00724349912557.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:08.854Z"
   },
   "cd-795-joe-lovano-gunther-schuller-rush-hour": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:52:16.258Z"
+    "resolvedAt": "2026-03-27T10:42:11.570Z"
   },
   "cd-796-joey-defrancesco-joey-defrancesco-s-good": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:18.111Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/e4/be/4d/e4be4d30-35ee-9d61-8bbf-6cd18d70c46b/00013431484523.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:12.892Z"
   },
   "cd-797-john-coltrane-a-love-supreme": {
     "url": "http://coverartarchive.org/release/1a23ef07-4d6f-444f-8680-96ba21651d72/14048476831-500.jpg",
@@ -4000,19 +4000,19 @@
     "resolvedAt": "2026-03-26T17:52:32.552Z"
   },
   "cd-800-john-coltrane-giant-steps": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:34.802Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/4e/2f/8b/4e2f8b1f-7e14-1ce4-1c76-4683b1b9173d/603497847549.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:14.210Z"
   },
   "cd-801-john-coltrane-impressions-capa-de-papel": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:52:36.744Z"
+    "resolvedAt": "2026-03-27T10:42:16.967Z"
   },
   "cd-802-john-coltrane-impressions-capa-de-plasti": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:52:38.638Z"
+    "resolvedAt": "2026-03-27T10:42:19.732Z"
   },
   "cd-803-john-coltrane-ole-coltrane": {
     "url": "http://coverartarchive.org/release/f0bd1b2e-bb84-36fc-a251-30d5f1c66b00/18781526649-500.jpg",
@@ -4020,29 +4020,29 @@
     "resolvedAt": "2026-03-26T17:52:43.144Z"
   },
   "cd-804-john-coltrane-soultrane": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:45.504Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/3b/e3/3e/3be33e63-5f6e-8157-97e2-68cf8bed1dab/00888072349735.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:21.014Z"
   },
   "cd-805-john-coltrane-stellar-regions": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:47.635Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/f9/0f/a5/f90fa5fb-cec6-3dfa-f82f-36c6b9e3a0e5/06UMGIM04180.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:22.332Z"
   },
   "cd-806-john-coltrane-quartet-ballads": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:49.861Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/d3/df/2d/d3df2d33-99b9-2edd-e7e7-9ee13bceb0db/06UMGIM14021.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:23.578Z"
   },
   "cd-807-john-coltrane-johnny-hartman-john-coltra": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:52:51.689Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/2b/6c/b7/2b6cb70e-8e01-1d96-f8f8-23aa73d5d7c2/06UMGIM09995.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:24.827Z"
   },
   "cd-808-john-engels-john-engels-quintet-in-conce": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:52:53.794Z"
+    "resolvedAt": "2026-03-27T10:42:27.701Z"
   },
   "cd-809-john-mclaughlin-my-goals-beyond": {
     "url": "http://coverartarchive.org/release/7887b8da-a8b0-4a78-8ab7-7415c42e4170/3003794135-500.jpg",
@@ -4070,9 +4070,9 @@
     "resolvedAt": "2026-03-26T17:53:17.012Z"
   },
   "cd-814-john-pizzarelli-meets-the-beatles": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:53:25.996Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/0f/52/e1/dj.jzqsipcc.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:29.029Z"
   },
   "cd-815-john-pizzarelli-one-night-with-you": {
     "url": "http://coverartarchive.org/release/4ea530b2-2e51-47d0-bac6-2da7dfb70fac/14203229443-500.jpg",
@@ -4090,9 +4090,9 @@
     "resolvedAt": "2026-03-26T17:53:38.220Z"
   },
   "cd-818-john-scofield-a-go-go": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:53:40.426Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/bb/e2/bb/bbe2bb1b-29d4-1e65-c7cd-5c564037616c/00731453997929.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:30.409Z"
   },
   "cd-819-john-scofield-bump": {
     "url": "http://coverartarchive.org/release/c70a3073-0646-3da7-9153-e30fde68f0bc/23015425930-500.jpg",
@@ -4115,14 +4115,14 @@
     "resolvedAt": "2026-03-26T17:53:56.729Z"
   },
   "cd-823-john-scofield-quiet": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:53:58.872Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/bd/c6/3b/bdc63b16-1a98-4be2-65db-61b536d695c7/00731453318526.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:31.711Z"
   },
   "cd-824-john-scofield-pat-metheny-i-can-see-your": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:00.809Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/c3/e1/91/c3e19156-a0fa-fcaa-66ea-b9fb3b74bc4d/00724382776550.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:33.130Z"
   },
   "cd-825-johnny-adams-the-verdict": {
     "url": "http://coverartarchive.org/release/e2fe88c9-635b-40cb-9c64-37c4564cde2a/26754846459-500.jpg",
@@ -4130,14 +4130,14 @@
     "resolvedAt": "2026-03-26T17:54:05.699Z"
   },
   "cd-826-johnny-hartman-priceless-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:07.987Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/6e/d7/4a/6ed74ab6-69d7-827a-3ed1-c422e28aaedd/06UMGIM05046.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:34.432Z"
   },
   "cd-827-johnny-hartman-songs-from-the-heart": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:10.331Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/41/49/11/414911c9-2c44-6633-eb9e-1a2b5ec75409/689466687095.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:35.920Z"
   },
   "cd-828-johnny-hartman-unforgettable": {
     "url": "http://coverartarchive.org/release/79495390-bd6b-402f-aba9-dd10c1263a29/38123851281-500.jpg",
@@ -4145,14 +4145,14 @@
     "resolvedAt": "2026-03-26T17:54:14.586Z"
   },
   "cd-829-johnny-hodges-triple-play": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:17.081Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/64/ec/62/64ec62bc-efae-a6a8-4edf-c7d7c3eef72a/886444353403.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:37.249Z"
   },
   "cd-830-al-jolson-20-reflective-recordings": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:54:18.951Z"
+    "resolvedAt": "2026-03-27T10:42:40.262Z"
   },
   "cd-831-jon-hendricks-boppin-at-the-blue-note": {
     "url": "http://coverartarchive.org/release/f94b199f-2a53-404a-920c-86b4b0a240ef/19130509605-500.jpg",
@@ -4160,9 +4160,9 @@
     "resolvedAt": "2026-03-26T17:54:24.200Z"
   },
   "cd-832-jon-lucien-endless-in-love": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:26.323Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/12/8a/e3/128ae349-e273-b0ff-e3e7-98527474d760/00016351503121_Cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:41.591Z"
   },
   "cd-833-michel-jonasz-les-fabuleux-moments-de-mi": {
     "url": "http://coverartarchive.org/release/77302f2a-1c83-47b4-9ce5-983b0f88248f/30443453847-500.jpg",
@@ -4180,9 +4180,9 @@
     "resolvedAt": "2026-03-26T17:54:41.833Z"
   },
   "cd-836-norah-jones-not-too-late": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:44.188Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/06/83/ff/0683ff32-d9f9-bf73-9807-18acd483fd1c/05099950769254.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:42.984Z"
   },
   "cd-837-quincy-jones-back-on-the-block": {
     "url": "http://coverartarchive.org/release/b221ea36-df40-4872-bb8f-46ad705b2ae9/4164037874-500.jpg",
@@ -4190,9 +4190,9 @@
     "resolvedAt": "2026-03-26T17:54:48.672Z"
   },
   "cd-838-jongui-eletrico-fio-que-teco": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:54:50.789Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/14/b4/eb/14b4eba1-462d-f4b9-fc1b-aff57c9538ba/7898226122964.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:44.295Z"
   },
   "cd-839-joni-mitchell-both-sides-now": {
     "url": "http://coverartarchive.org/release/d0d20f6e-43ec-35cb-93ae-dfe5d4b485df/11827909359-500.jpg",
@@ -4222,7 +4222,7 @@
   "cd-844-pat-metheny-anna-maria-jopek-upojenie": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:55:17.434Z"
+    "resolvedAt": "2026-03-27T10:42:47.067Z"
   },
   "cd-845-janis-joplin-box-of-pearls-the-janis-jop": {
     "url": "http://coverartarchive.org/release/50dea83c-4981-35e7-8d24-538947ca3f1c/15843799347-500.jpg",
@@ -4232,12 +4232,12 @@
   "cd-846-jorge-fernandes-francisco-alves-gastao-f": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:55:23.949Z"
+    "resolvedAt": "2026-03-27T10:42:49.772Z"
   },
   "cd-847-jose-miguel-wisnik-sao-paulo-rio": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:25.827Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/68/54/26/685426a5-76c8-d549-a0a1-60508528973f/7898936520173.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:51.049Z"
   },
   "cd-848-joshua-redman-beyond": {
     "url": "http://coverartarchive.org/release/d75bf7b1-bfd4-4b3e-b45b-6592318a26ab/21069616381-500.jpg",
@@ -4250,14 +4250,14 @@
     "resolvedAt": "2026-03-26T17:55:33.802Z"
   },
   "cd-850-joshua-redman-timeless-tales-for-changin": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:35.919Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ce/17/14/mzi.heohmvvm.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:53.108Z"
   },
   "cd-851-joshua-redman-wish": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:38.049Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/ab/87/9a/ab879a6f-d941-e1b0-d3a9-e912a722c765/mzi.ltvdkbxi.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:54.757Z"
   },
   "cd-852-joshua-redman-quartet-spirit-of-the-mome": {
     "url": "http://coverartarchive.org/release/0708b7c7-cb2c-47f7-ba3e-44e09cb25e82/15066202971-500.jpg",
@@ -4270,29 +4270,29 @@
     "resolvedAt": "2026-03-26T17:55:46.393Z"
   },
   "cd-854-joyce-joyce-ao-vivo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:48.222Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/b9/a6/a0/b9a6a050-aa8e-2c32-93fb-db8510dfd118/8023353055451.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:42:55.987Z"
   },
   "cd-855-juarez-araujo-bossa-nova-nos-states": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:55:50.099Z"
+    "resolvedAt": "2026-03-27T10:42:58.708Z"
   },
   "cd-856-juca-novaes-eduardo-santana-lua-do-brasi": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:51.951Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/b6/93/cc/b693cc9e-9a07-45b4-1465-430a2515e599/0632627956325.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:00.025Z"
   },
   "cd-857-jungle-funk-jungle-funk": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:54.181Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/54/6c/22/546c2287-ba7b-eab0-3d78-fcfc8efb953a/artwork.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:01.285Z"
   },
   "cd-858-kansas-city-band-kc-after-dark": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:55:56.119Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/00/38/40/0038400a-4552-86f3-3314-b3ea250bc126/00731453732223.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:02.545Z"
   },
   "cd-859-herbert-von-karajan-karajan-forever-the-": {
     "url": "http://coverartarchive.org/release/d83acec6-8022-4c22-81b9-bd9177c48bfa/23015596188-500.jpg",
@@ -4300,14 +4300,14 @@
     "resolvedAt": "2026-03-26T17:56:01.637Z"
   },
   "cd-860-kasper-villaume-hands": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:56:03.978Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/99/74/dd/9974dd31-f65d-dcb8-c5ec-a52f110d3467/829410587853.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:03.835Z"
   },
   "cd-861-kazumi-watanabe-kilowatt": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:56:06.192Z"
+    "resolvedAt": "2026-03-27T10:43:06.689Z"
   },
   "cd-862-keith-jarrett-my-song": {
     "url": "http://coverartarchive.org/release/baf523b1-6e32-35bc-bfe3-90a008b7f288/34878348372-500.jpg",
@@ -4320,9 +4320,9 @@
     "resolvedAt": "2026-03-26T17:56:14.782Z"
   },
   "cd-864-keith-jarrett-trio-whisper-not": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:56:16.959Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/09/f4/4d/09f44d8d-455c-5b65-1b2c-f8b94676996e/00731454381628.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:08.008Z"
   },
   "cd-865-kenny-barron-things-unseen": {
     "url": "http://coverartarchive.org/release/1b2b2df3-c2c8-4ce3-8ec4-10f4c5601511/8144452216-500.jpg",
@@ -4335,9 +4335,9 @@
     "resolvedAt": "2026-03-26T17:56:30.054Z"
   },
   "cd-867-kenny-garrett-simply-said": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:56:32.434Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f8/2f/e5/mzi.ewxppdcu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:09.238Z"
   },
   "cd-868-kenny-garrett-songbook": {
     "url": "http://coverartarchive.org/release/68400632-c7e3-4426-a06e-cfc354e39d15/34943499040-500.jpg",
@@ -4345,19 +4345,19 @@
     "resolvedAt": "2026-03-26T17:56:36.613Z"
   },
   "cd-869-kenny-garrett-triology": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:56:38.710Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/85/b7/58/mzi.tezoxmco.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:10.595Z"
   },
   "cd-870-stan-kenton-live-spotlight-on-lee-konitz": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:56:40.935Z"
+    "resolvedAt": "2026-03-27T10:43:14.170Z"
   },
   "cd-871-kevin-eubanks-spiritalk-2": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:56:43.035Z"
+    "resolvedAt": "2026-03-27T10:43:17.346Z"
   },
   "cd-872-kevin-mahogany-another-time-another-plac": {
     "url": "http://coverartarchive.org/release/392a36ce-2586-4ca3-98bd-ba0dc984448a/14222466236-500.jpg",
@@ -4407,17 +4407,17 @@
   "cd-881-king-crimson-thrakattak": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:57:30.331Z"
+    "resolvedAt": "2026-03-27T10:43:20.577Z"
   },
   "cd-882-b-b-king-the-definitive-b-b-king-collect": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:57:32.193Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/6a/18/8c/6a188cd2-3e60-8116-2183-fb51f9b5fea0/09UMGIM27654.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:21.913Z"
   },
   "cd-883-john-klemmer-mosaic-the-best-of-volume-o": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:57:34.153Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/58/40/0b/58400b7a-c502-9bf0-892b-eaaa7e42ecde/00011105983822.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:23.291Z"
   },
   "cd-884-diana-krall-from-this-moment-on": {
     "url": "http://coverartarchive.org/release/3c90b98f-e8d3-4001-850f-00a8a73b9aac/8705958581-500.jpg",
@@ -4445,9 +4445,9 @@
     "resolvedAt": "2026-03-26T17:57:54.870Z"
   },
   "cd-889-kurt-elling-the-messenger": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:57:57.133Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/1b/2a/2b/1b2a2b37-c111-6a6c-4952-a10e2afc9176/00724385272752.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:24.663Z"
   },
   "cd-890-kurt-elling-this-time-it-s-love": {
     "url": "http://coverartarchive.org/release/735ece48-cd1b-4090-b247-9d7bd69952a6/14231092122-500.jpg",
@@ -4470,19 +4470,19 @@
     "resolvedAt": "2026-03-26T17:58:13.462Z"
   },
   "cd-894-larika-larika": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:58:15.353Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music20/v4/11/0a/90/110a9046-bb7d-e808-6669-5f8bf1325a82/190394654368.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:25.908Z"
   },
   "cd-895-larry-coryell-american-odissey": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:58:17.188Z"
+    "resolvedAt": "2026-03-27T10:43:28.881Z"
   },
   "cd-896-larry-coryell-live-from-bahia": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:58:19.387Z"
+    "resolvedAt": "2026-03-27T10:43:31.869Z"
   },
   "cd-897-larry-coryell-spaces-revisited": {
     "url": "http://coverartarchive.org/release/8e1f8003-570d-4f72-a41e-09291cdd90db/24400885932-500.jpg",
@@ -4490,9 +4490,9 @@
     "resolvedAt": "2026-03-26T17:58:24.024Z"
   },
   "cd-898-larry-coryell-philip-catherine-twin-hous": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:58:26.086Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/a4/ed/38/a4ed3849-176e-bf0f-708b-67a3e6ffa40f/5059460280212.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:33.188Z"
   },
   "cd-899-larry-goldings-awareness": {
     "url": "http://coverartarchive.org/release/65c06433-7e35-4d51-bb1d-470f40646ff8/23048855481-500.jpg",
@@ -4520,9 +4520,9 @@
     "resolvedAt": "2026-03-26T17:58:48.179Z"
   },
   "cd-904-rita-lee-aqui-ali-em-qualquer-lugar": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:58:50.399Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music5/v4/77/90/2e/77902e82-796f-3405-2a72-60a3fd26e3ce/7898324300615.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:34.451Z"
   },
   "cd-905-rita-lee-rita-lee-em-bossa-n-roll": {
     "url": "http://coverartarchive.org/release/73657010-6327-4402-ab68-095ce4d15031/16261215281-500.jpg",
@@ -4532,7 +4532,7 @@
   "cd-906-rita-lee-the-greatest-hits-lanca-perfume": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:58:57.642Z"
+    "resolvedAt": "2026-03-27T10:43:37.174Z"
   },
   "cd-907-legiao-urbana-acustico-mtv": {
     "url": "http://coverartarchive.org/release/c5bf48e6-6678-4c23-aa1c-7692a8231f74/36031852947-500.jpg",
@@ -4540,9 +4540,9 @@
     "resolvedAt": "2026-03-26T17:59:02.094Z"
   },
   "cd-908-leila-pinheiro-isso-e-bossa-nova": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:59:04.802Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/bf/0f/48/bf0f486a-5889-a0da-1f87-4549901f0d18/05099951658656.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:38.560Z"
   },
   "cd-909-lena-horne-being-myself": {
     "url": "http://coverartarchive.org/release/5ea5212b-1587-4f31-99ae-83bc64e2df87/3653730374-500.jpg",
@@ -4560,9 +4560,9 @@
     "resolvedAt": "2026-03-26T17:59:17.854Z"
   },
   "cd-912-lennie-tristano-lennie-tristano-the-new-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:59:20.056Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/y2005/m03/d14/h21/s06.dmxuetbf.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:39.834Z"
   },
   "cd-913-leon-parker-above-below": {
     "url": "http://coverartarchive.org/release/db188a84-f880-45c1-bd0c-7defb6e04194/4271721082-500.jpg",
@@ -4580,9 +4580,9 @@
     "resolvedAt": "2026-03-26T17:59:34.818Z"
   },
   "cd-916-leopold-stokowski-the-philadelphia-orche": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:59:36.748Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/70/bc/7b/70bc7b8a-81b6-4d7a-3a5b-340b795c0756/09BVMIM00013.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:41.379Z"
   },
   "cd-917-les-double-six-les-double-six-rencontren": {
     "url": "http://coverartarchive.org/release/42e2e2bb-99d4-4608-85c4-4e45b40831e2/36813471001-500.jpg",
@@ -4590,9 +4590,9 @@
     "resolvedAt": "2026-03-26T17:59:41.440Z"
   },
   "cd-918-level-42-level-best-a-collection-of-thei": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T17:59:43.518Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/91/8d/83/918d8362-d3d8-1dba-0091-3089c3a7ecdf/19UM1IM09894.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:42.932Z"
   },
   "cd-919-level-42-live-at-wembley": {
     "url": "http://coverartarchive.org/release/61fdc098-a8fb-4843-9b7b-aaa55faedb70/13755121695-500.jpg",
@@ -4602,7 +4602,7 @@
   "cd-920-leviev-slon-quartet-jive-sambas": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T17:59:50.483Z"
+    "resolvedAt": "2026-03-27T10:43:46.554Z"
   },
   "cd-921-ottmar-liebert-nouveau-flamenco": {
     "url": "http://coverartarchive.org/release/65515613-c20c-462c-a846-a43284d9cc15/29174988868-500.jpg",
@@ -4630,9 +4630,9 @@
     "resolvedAt": "2026-03-26T18:00:11.585Z"
   },
   "cd-926-lisa-ekdahl-sings-salvadore-poe": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:13.896Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/51/8e/cf/518ecf43-63ac-2960-d9f4-d45adf04cd3e/743217968120.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:47.917Z"
   },
   "cd-927-little-richard-good-golly-miss-molly": {
     "url": "http://coverartarchive.org/release/ea584ac1-c42c-4f7d-96ee-d43b256a8f12/38332230358-500.jpg",
@@ -4640,9 +4640,9 @@
     "resolvedAt": "2026-03-26T18:00:21.154Z"
   },
   "cd-928-living-colour-time-s-up": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:23.461Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/db/a8/1c/dba81c3a-e583-68b9-e056-6171735757a8/mzi.thhrijqw.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:49.164Z"
   },
   "cd-929-living-colour-vivid": {
     "url": "http://coverartarchive.org/release/a18188e6-7978-4449-a7c0-a8796ef3b08f/26335736501-500.jpg",
@@ -4652,17 +4652,17 @@
   "cd-930-the-london-starlight-orchestra-globo-col": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:00:30.182Z"
+    "resolvedAt": "2026-03-27T10:43:51.925Z"
   },
   "cd-931-london-symphony-orchestra-tommy-as-perfo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:32.058Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music5/v4/31/eb/59/31eb5952-32ca-51da-de87-82ca1f5a9d61/889845536154.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:53.187Z"
   },
   "cd-932-lonnie-smith-afro-blue": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:34.231Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/44/82/da/4482da9f-7857-ea1b-54ec-21af9f1a8da8/mzi.iilbjbga.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:54.487Z"
   },
   "cd-933-lonnie-smith-live-at-club-mozambique": {
     "url": "http://coverartarchive.org/release/99b644a7-f948-474c-8ca5-177954acd03a/28927365582-500.jpg",
@@ -4670,19 +4670,19 @@
     "resolvedAt": "2026-03-26T18:00:38.869Z"
   },
   "cd-934-josi-lopes-essencia": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:40.877Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/97/b5/7c/97b57c7b-a61d-6a5c-3701-2c2a20e062e5/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:43:55.762Z"
   },
   "cd-935-trini-lopez-ao-vivo-outra-vez": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:00:42.736Z"
+    "resolvedAt": "2026-03-27T10:43:58.806Z"
   },
   "cd-936-trini-lopez-the-latin-album": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:45.444Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/33/22/f3/3322f36d-4d38-8d85-7a90-4e26e54d687c/603497921997.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:00.107Z"
   },
   "cd-937-los-hombres-calientes-los-hombres-calien": {
     "url": "http://coverartarchive.org/release/0b5283d2-1c99-4a9b-85f9-46c6b1937c96/3128721512-500.jpg",
@@ -4690,9 +4690,9 @@
     "resolvedAt": "2026-03-26T18:00:50.420Z"
   },
   "cd-938-los-hombres-calientes-los-hombres-calien": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:00:52.749Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/0f/27/47/mzi.odskexgs.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:01.382Z"
   },
   "cd-939-lou-donaldson-sentimental-journey": {
     "url": "http://coverartarchive.org/release/01053c16-dd39-432f-b1a1-7f23f4a6f43f/8280099185-500.jpg",
@@ -4705,79 +4705,79 @@
     "resolvedAt": "2026-03-26T18:01:03.873Z"
   },
   "cd-941-lou-rawl-at-last": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:05.885Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/78/e2/c2/78e2c291-2940-8075-366b-a52745584be8/00077779193752.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:02.643Z"
   },
   "cd-942-louis-armstrong-hot-fives-hot-sevens-vol": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:07.810Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/54/10/9d/mzi.tzqujtgu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:03.988Z"
   },
   "cd-943-louis-armstrong-the-hot-fives-volume-1": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:09.887Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/54/10/9d/mzi.tzqujtgu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:05.539Z"
   },
   "cd-944-luar-na-lubre-ara-solis": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:12.203Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music127/v4/a3/db/ed/a3dbed83-26e9-68f1-335c-ccba26699d4c/191018758721.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:06.868Z"
   },
   "cd-945-romero-lubambo-two": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:14.050Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/d0/46/27/d0462729-2c7d-99d8-4d10-f80e62726267/1697iTunes.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:08.385Z"
   },
   "cd-946-lucio-alves-lucio-alves-serie-acervo-esp": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:01:15.875Z"
+    "resolvedAt": "2026-03-27T10:44:11.332Z"
   },
   "cd-947-ludwig-van-beethoven-berliner-philharmon": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:17.729Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/e4/e3/1b/e4e31bb4-b7c5-c7aa-d9df-200f764f4220/06UMGIM42327.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:12.610Z"
   },
   "cd-948-ludwig-van-beethoven-philharmonia-slavon": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:19.632Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/67/79/06/dj.xvlissoi.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:13.929Z"
   },
   "cd-949-ludwig-van-beethoven-the-royal-philharmo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:21.588Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/b1/90/de/b190de31-1b1c-e399-a907-eda8ab0c801f/26UMGIM04378.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:15.184Z"
   },
   "cd-950-luiz-waack-maguari": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:23.554Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/03/39/19/033919bc-113c-e1e4-5087-aef087ec4b15/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:16.576Z"
   },
   "cd-951-lulina-pantim": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:25.394Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/57/71/67/577167e6-3331-4ae4-279b-f374d87d16c5/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:17.880Z"
   },
   "cd-952-cheryl-lynn-the-best-of-cheryl-lynn-got-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:27.396Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/bc/04/43/mzi.fjmkokwb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:19.138Z"
   },
   "cd-953-yo-yo-ma-obrigado-brazil": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:30.349Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/d5/4f/e8/d54fe842-0778-680c-7c18-092d304bf54f/mzi.raxztokn.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:20.467Z"
   },
   "cd-954-sizao-machado-cd-piloto": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:01:32.311Z"
+    "resolvedAt": "2026-03-27T10:44:23.285Z"
   },
   "cd-955-madeleine-peyroux-careless-love": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:34.400Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/c4/ad/ca/c4adcac5-d1ab-b171-af59-7d6df0b397e6/00888072049338.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:24.517Z"
   },
   "cd-956-madeleine-peyroux-dreamland": {
     "url": "http://coverartarchive.org/release/f2865eae-c669-4c93-854d-34559ce86298/14265603119-500.jpg",
@@ -4800,9 +4800,9 @@
     "resolvedAt": "2026-03-26T18:01:51.696Z"
   },
   "cd-960-madredeus-ainda": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:01:53.803Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/71/d9/b4/71d9b45f-bd16-fd53-77a4-a8b294599086/724383263653.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:25.830Z"
   },
   "cd-961-madredeus-lisboa": {
     "url": "http://coverartarchive.org/release/7ab2fc8d-74a6-46d5-afe4-a8db97e1f3c4/21200956484-500.jpg",
@@ -4830,9 +4830,9 @@
     "resolvedAt": "2026-03-26T18:02:18.862Z"
   },
   "cd-966-mahler-symphony-5-gustav-mahler-symphony": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:02:21.303Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/v4/db/0b/79/db0b79aa-d96d-143b-cd61-c9fe466c7db9/dj.npxwfgmn.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:27.074Z"
   },
   "cd-967-tim-maia-o-descobridor-dos-sete-mares": {
     "url": "http://coverartarchive.org/release/55e832ab-038e-412f-86b4-52907440ef8b/5039480871-500.jpg",
@@ -4845,19 +4845,19 @@
     "resolvedAt": "2026-03-26T18:02:29.786Z"
   },
   "cd-969-maira-freitas-maira-freitas": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:02:31.938Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/71/30/eb/7130eb27-e944-2cd7-5df0-f28947cb6dcf/mzi.bxppsfkk.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:28.406Z"
   },
   "cd-970-carlos-malta-pimenta": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:02:33.885Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/fe/b4/8c/feb48c04-a675-2f4b-1481-b2bb2e3042b2/60471401-c514-41cf-a030-ee2f3cdf77ba.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:29.725Z"
   },
   "cd-971-the-mamas-the-papas-16-greatest-hits": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:02:35.805Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/56/fa/40/56fa40d9-e57e-22be-8f45-3e8d5c1acc77/06UMGIM04098.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:31.379Z"
   },
   "cd-972-mandu-sarara-mandu-sarara": {
     "url": "http://coverartarchive.org/release/ef544f99-5e54-47f4-8734-1caceb648e84/17948583531-500.jpg",
@@ -4867,12 +4867,12 @@
   "cd-973-mane-silveira-bonsai-machine": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:02:43.938Z"
+    "resolvedAt": "2026-03-27T10:44:34.136Z"
   },
   "cd-974-mane-silveira-sax-sob-as-arvores": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:02:46.088Z"
+    "resolvedAt": "2026-03-27T10:44:37.730Z"
   },
   "cd-975-barry-manilow-singin-with-the-big-bands": {
     "url": "http://coverartarchive.org/release/7419cf4e-15f2-4711-afaf-819a6a973b2c/27495507155-500.jpg",
@@ -4880,19 +4880,19 @@
     "resolvedAt": "2026-03-26T18:02:52.631Z"
   },
   "cd-976-marc-cary-listen": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:02:55.258Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/3b/a4/a7/mzi.zcupbmhn.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:38.976Z"
   },
   "cd-977-marc-cary-trillium": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:02:57.367Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/y2005/m07/d06/h02/s07.gxicrojc.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:40.225Z"
   },
   "cd-978-marc-liebenskind-duvida": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:02:59.244Z"
+    "resolvedAt": "2026-03-27T10:44:43.006Z"
   },
   "cd-979-marcelinho-da-lua-social": {
     "url": "http://coverartarchive.org/release/1a35b3ae-ced8-4ccb-8432-8de978907308/14978715364-500.jpg",
@@ -4905,19 +4905,19 @@
     "resolvedAt": "2026-03-26T18:03:08.815Z"
   },
   "cd-981-marcelo-niero-apocalipse": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:10.727Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music22/v4/e7/ad/02/e7ad02a8-082c-a7b4-c9ee-5563afc5fedf/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:44.300Z"
   },
   "cd-982-marcia-salomon-geminiana": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:12.589Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/2d/9f/53/2d9f5357-a12b-ae8c-1f0f-af593d6e0668/7898339030385.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:45.548Z"
   },
   "cd-983-marcinho-eiras-my-project": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:03:14.593Z"
+    "resolvedAt": "2026-03-27T10:44:48.260Z"
   },
   "cd-984-marcio-montarroyos-marcio-montarroyos": {
     "url": "http://coverartarchive.org/release/432b559b-1924-419f-82f4-8adc46a08a2e/21255528419-500.jpg",
@@ -4935,24 +4935,24 @@
     "resolvedAt": "2026-03-26T18:03:27.269Z"
   },
   "cd-987-marco-andre-amazonia-groove": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:29.172Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/55/53/a6/5553a6e0-8a07-a151-0e77-0e9b2a6ee9e9/0632627989026.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:49.520Z"
   },
   "cd-988-marco-andre-beat-iu": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:30.995Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/b0/3f/5d/b03f5d36-1ff5-e85a-4f11-33e92b17e1f4/7898334790048.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:50.837Z"
   },
   "cd-989-marco-aurelio-serestas-para-matar-minha-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:33.157Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/27/f0/ec/mzi.bzhcowrz.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:52.092Z"
   },
   "cd-990-marcos-sacramento-sacramentos": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:35.237Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/c1/54/89/c1548910-9c38-ed01-35c1-68d7fbcb5873/192562603468.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:53.649Z"
   },
   "cd-991-marcus-printup-nocturnal-traces": {
     "url": "http://coverartarchive.org/release/c65552b3-fccd-4a33-845b-d12f3d48e3b6/4400979668-500.jpg",
@@ -4965,29 +4965,29 @@
     "resolvedAt": "2026-03-26T18:03:44.618Z"
   },
   "cd-993-marcus-printup-tim-hagans-hubsongs": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:46.535Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/d7/03/cb/d703cb2f-0782-0f71-85d7-ef5591dd9910/00602537871407.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:55.043Z"
   },
   "cd-994-maria-alvim-rhythm-romance": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:48.461Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/52/f9/76/52f976b0-016e-a3bf-1897-f69fb5d002d7/mzi.csyboqno.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:44:56.386Z"
   },
   "cd-995-maria-augusta-classics-in-bossa": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:03:50.452Z"
+    "resolvedAt": "2026-03-27T10:44:59.212Z"
   },
   "cd-996-maria-joao-mario-laginha-chorinho-feliz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:03:52.606Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/6f/20/e4/6f20e40b-46f3-7d09-00c5-baf7d9c35ad7/00731454374927.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:00.529Z"
   },
   "cd-997-maria-joao-e-mario-laginha-cor": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:03:54.430Z"
+    "resolvedAt": "2026-03-27T10:45:03.265Z"
   },
   "cd-998-maria-schneider-coming-about": {
     "url": "https://coverartarchive.org/release/19a24a08-b0d5-40b1-8e85-a355cfd8e1e1/10901798700-500.jpg",
@@ -5045,9 +5045,9 @@
     "resolvedAt": "2026-03-26T18:04:43.994Z"
   },
   "cd-1009-mark-whitfield-forever-love": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:04:46.307Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/b8/94/d0/b894d03a-386b-7d88-7f3d-9f648cdbcb6b/00731453392120.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:04.611Z"
   },
   "cd-1010-george-martin-in-my-life": {
     "url": "http://coverartarchive.org/release/12bc6839-0bb9-4aea-b42f-8969bb513f56/9831682392-500.jpg",
@@ -5075,9 +5075,9 @@
     "resolvedAt": "2026-03-26T18:05:08.685Z"
   },
   "cd-1015-maurice-ravel-claude-debussy-camille-sai": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:05:10.711Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/85/e2/d5/85e2d59a-1641-2999-cb2c-eedc6f1954c5/00028943901420.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:05.859Z"
   },
   "cd-1016-max-roach-to-the-max": {
     "url": "http://coverartarchive.org/release/8e43b576-2d99-4f74-8355-82b28d758784/19210102241-500.jpg",
@@ -5090,9 +5090,9 @@
     "resolvedAt": "2026-03-26T18:05:20.634Z"
   },
   "cd-1018-maysa-grandes-vozes": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:05:22.625Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/ff/c2/5f/ffc25f04-cb3b-b56e-dd28-8b77ae63e613/00602537070824.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:07.128Z"
   },
   "cd-1019-maysa-maysa": {
     "url": "http://coverartarchive.org/release/7bf8c99e-922b-42a9-a166-36822d321c1d/9246603244-500.jpg",
@@ -5100,9 +5100,9 @@
     "resolvedAt": "2026-03-26T18:05:27.056Z"
   },
   "cd-1020-maysa-popular-brasileira": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:05:29.149Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/94/4d/9a/944d9a8d-0549-f537-5706-5b083bd84a7d/21UM1IM38949.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:08.449Z"
   },
   "cd-1021-paul-mccartney-memory-almost-full": {
     "url": "http://coverartarchive.org/release/975d4670-5a9d-41ff-b886-38ea760813c6/1517221001-500.jpg",
@@ -5115,14 +5115,14 @@
     "resolvedAt": "2026-03-26T18:05:36.905Z"
   },
   "cd-1023-paul-mccartney-run-devil-run": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:05:39.657Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/a9/ad/73/a9ad73df-5f9d-0d5e-f8fd-3882d532fdea/19UM1IM01018.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:09.740Z"
   },
   "cd-1024-paul-mccartney-unplugged-the-official-bo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:05:43.720Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/e0/de/b4/e0deb4c7-4e5b-11d3-2b07-b34fa38e2ca0/00888072321670.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:11.064Z"
   },
   "cd-1025-mccoy-tyner-mccoy-tyner-with-stanley-cla": {
     "url": "http://coverartarchive.org/release/2e44bfc1-7753-44f8-9a74-8395ab0af5b7/36875556355-500.jpg",
@@ -5145,44 +5145,44 @@
     "resolvedAt": "2026-03-26T18:05:59.312Z"
   },
   "cd-1029-john-mclaughlin-al-di-meola-paco-de-luci": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:01.205Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/4b/2e/30/4b2e306d-7f6e-6a16-607a-cfa31b53ef80/074646516829.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:12.435Z"
   },
   "cd-1030-don-mclean-american-pie": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:03.468Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/7a/fd/77/7afd77f5-a928-109c-5da5-c591b8dad4b2/13UABIM59293.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:13.734Z"
   },
   "cd-1031-medeski-martin-and-wood-combustication": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:05.616Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/ff/2a/5c/ff2a5cf6-96fa-caed-0a2d-cfd0b4ed7fd3/00602537642687.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:15.045Z"
   },
   "cd-1032-medeski-martin-and-wood-last-chance-to-d": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:07.776Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/f2/e3/ff/f2e3ff99-105b-b8ba-8e75-6958f6db4ace/mzi.gnlxzkjp.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:16.353Z"
   },
   "cd-1033-medeski-martin-and-wood-tonic": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:09.899Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/bf/f6/8a/bff68a0d-8d90-b6a1-2003-0517d9f1b416/00724352527151.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:17.932Z"
   },
   "cd-1034-medeski-scofield-martin-and-wood-outloud": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:11.928Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music3/v4/bf/06/6e/bf066e2d-629c-cac2-919f-efb82ab88f04/888880853035.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:19.673Z"
   },
   "cd-1035-andre-mehmari-gabriele-mirabassi-miramar": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:06:13.919Z"
+    "resolvedAt": "2026-03-27T10:45:23.085Z"
   },
   "cd-1036-pascoal-meirelles-paula": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:06:15.927Z"
+    "resolvedAt": "2026-03-27T10:45:25.803Z"
   },
   "cd-1037-mel-torme-a-tribute-to-bing-crosby": {
     "url": "http://coverartarchive.org/release/4ba87b52-a675-4cd0-9419-ca3fcf4362f5/35170566432-500.jpg",
@@ -5195,9 +5195,9 @@
     "resolvedAt": "2026-03-26T18:06:24.875Z"
   },
   "cd-1039-mel-torme-nothing-without-you": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:27.402Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/7f/a2/0c/7fa20c18-1a34-d442-0d82-66eab2ace4c7/00013431451525.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:27.060Z"
   },
   "cd-1040-mel-torme-prelude-to-a-kiss": {
     "url": "http://coverartarchive.org/release/b45526e5-69dc-4a01-a7d6-93d89e589cb2/14296254665-500.jpg",
@@ -5210,19 +5210,19 @@
     "resolvedAt": "2026-03-26T18:06:40.086Z"
   },
   "cd-1042-melissa-errico-blue-like-that": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:42.144Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/51/7e/d4/517ed47a-c307-39a6-39dc-3c748c1f5b44/00724353466459.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:28.306Z"
   },
   "cd-1043-luiz-melodia-luiz-melodia-convida-ao-viv": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:06:44.224Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/02/2e/47/022e474b-e3b0-1655-02ee-f1f6a0bb9737/7898420120827.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:29.648Z"
   },
   "cd-1044-luiz-melodia-minha-historia": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:06:46.058Z"
+    "resolvedAt": "2026-03-27T10:45:32.408Z"
   },
   "cd-1045-melody-gardot-my-one-and-only-thrill": {
     "url": "http://coverartarchive.org/release/0fa561d7-71fa-448c-86cb-7899fa1d7c93/3756366856-500.jpg",
@@ -5250,9 +5250,9 @@
     "resolvedAt": "2026-03-26T18:07:08.103Z"
   },
   "cd-1050-the-meters-the-very-best-of-the-meters": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:07:10.422Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ed/62/d2/mzi.bupngrkr.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:33.723Z"
   },
   "cd-1051-michael-feinstein-remember-michael-feins": {
     "url": "http://coverartarchive.org/release/b01499f3-8896-47c4-8c38-1debddb0c974/30005428157-500.jpg",
@@ -5265,19 +5265,19 @@
     "resolvedAt": "2026-03-26T18:07:18.920Z"
   },
   "cd-1053-michael-petrucciani-concerts-inedits": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:07:20.824Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/e5/1f/5b/e51f5b03-35e9-d711-061e-e678b8cc7630/3460503660724.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:35.067Z"
   },
   "cd-1054-michael-petrucciani-marvellous": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:07:22.903Z"
+    "resolvedAt": "2026-03-27T10:45:37.783Z"
   },
   "cd-1055-michael-petrucciani-michael-petrucciani": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:07:26.131Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/ce/59/ef/ce59efef-0713-3ade-84e5-8dddd7fedd7d/0886443544116.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:39.068Z"
   },
   "cd-1056-michel-camilo-one-more-once": {
     "url": "http://coverartarchive.org/release/bca718d7-1f22-416c-aa1e-a25c523b9b14/14269844910-500.jpg",
@@ -5300,9 +5300,9 @@
     "resolvedAt": "2026-03-26T18:07:47.070Z"
   },
   "cd-1060-mike-stern-play": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:07:49.209Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/0f/66/ff/0f66ff95-4591-10df-4fd0-91ed235b7cbf/18CRGIM06405.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:40.309Z"
   },
   "cd-1061-miles-davis-amandla": {
     "url": "http://coverartarchive.org/release/595d385f-994c-40e9-b86b-fe12a686ebc0/36889158707-500.jpg",
@@ -5360,9 +5360,9 @@
     "resolvedAt": "2026-03-26T18:08:32.656Z"
   },
   "cd-1072-miles-davis-my-funny-valentine": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:34.804Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/v4/25/5d/b8/255db836-7305-3cf6-1d6f-06f8ac2d9af6/dj.vilpcmjm.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:41.839Z"
   },
   "cd-1073-miles-davis-porgy-and-bess": {
     "url": "http://coverartarchive.org/release/6791b088-2bfd-4b69-b227-c1e133d87d26/31638489158-500.jpg",
@@ -5370,34 +5370,34 @@
     "resolvedAt": "2026-03-26T18:08:40.709Z"
   },
   "cd-1074-miles-davis-quincy-jones-miles-quincy-li": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:42.782Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/b0/ba/b9/mzi.oqpbvmby.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:43.224Z"
   },
   "cd-1075-glenn-miller-the-best-of-glenn-miller": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:44.876Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/1d/c8/ff/1dc8ff05-307c-0734-17ed-6a5f7bd645ff/mzi.varbrygk.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:44.595Z"
   },
   "cd-1076-vange-milliet-vange-milliet": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:46.770Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/09/45/c1/mzi.wqphvjyq.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:45.952Z"
   },
   "cd-1077-milt-jackson-milt-jackson-and-the-thelon": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:48.638Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/be/c0/8f/bec08f53-6888-be4e-3114-c7814e4084ee/19UMGIM53858.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:47.191Z"
   },
   "cd-1078-milt-jackson-reverence-and-compassion": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:50.803Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/0c/a5/05/0ca5051a-81c2-288a-0be0-0e36ae4a8167/5059460188013.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:48.526Z"
   },
   "cd-1079-milt-jackson-sa-va-bella": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:08:53.002Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/d1/b1/16/mzi.svgjkflv.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:49.850Z"
   },
   "cd-1080-carmen-miranda-carmen-miranda": {
     "url": "https://coverartarchive.org/release/212423a3-71a0-442b-82f3-c3047283bf39/44141297448-500.jpg",
@@ -5407,32 +5407,32 @@
   "cd-1081-carmen-miranda-carmen-miranda-box-5-cds": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:08:59.982Z"
+    "resolvedAt": "2026-03-27T10:45:53.214Z"
   },
   "cd-1082-keb-mo-just-like-you": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:02.103Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/19/80/63/198063c6-d07f-4fdd-71d1-7bc7b4f1bab1/mzi.ulwyduzw.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:54.452Z"
   },
   "cd-1083-moacir-santos-ouro-negro": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:04.302Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/c0/b4/ac/c0b4ac99-ed75-bdba-e459-9cb6eda42f95/823421101121.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:55.758Z"
   },
   "cd-1084-mobile-tomorrow-starts-today": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:16.953Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/9c/55/6c/9c556c6b-21c1-4317-1b08-f24e9506aad4/00050087377748.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:57.070Z"
   },
   "cd-1085-monica-salmaso-voadeira": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:19.654Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/c3/c4/03/c3c4032a-d313-d5dc-9fed-f2c314dba8b1/00085365452657_Cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:58.339Z"
   },
   "cd-1086-monica-vasconcelos-nois": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:21.804Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/18/26/0e/18260e7a-54f1-f084-5d5d-4a6a478ffe1a/109370.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:45:59.674Z"
   },
   "cd-1087-thelonious-monk-thelonious-monk": {
     "url": "http://coverartarchive.org/release/c25c8275-0f74-4caf-b3f9-e2c6da2bb0c3/24020856474-500.jpg",
@@ -5440,19 +5440,19 @@
     "resolvedAt": "2026-03-26T18:09:33.654Z"
   },
   "cd-1088-marisa-monte-ainda-lembro": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:35.664Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/8f/d3/37/8fd33722-ba9e-a57c-65f2-477e1833f772/00094637461457.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:01.121Z"
   },
   "cd-1089-marisa-monte-barulhinho-bom-cd1-ao-vivo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:09:37.554Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/8f/d3/37/8fd33722-ba9e-a57c-65f2-477e1833f772/00094637461457.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:02.370Z"
   },
   "cd-1090-marisa-monte-colecao": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:10:15.998Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/94/30/c3/9430c380-d2e7-81c3-8893-54dd0fec952d/195081542133.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:03.665Z"
   },
   "cd-1091-marisa-monte-marisa-monte": {
     "url": "http://coverartarchive.org/release/7e01f526-d786-4d03-87c8-1677f2807fb5/7015225648-500.jpg",
@@ -5460,14 +5460,14 @@
     "resolvedAt": "2026-03-26T18:10:22.379Z"
   },
   "cd-1092-marisa-monte-memorias-cronicas-e-declara": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:10:25.566Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/71/f2/f5/71f2f501-0941-b439-1e55-d956a7cc6e43/195081556666.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:05.026Z"
   },
   "cd-1093-juarez-moreira-nuvens-douradas": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:10:27.645Z"
+    "resolvedAt": "2026-03-27T10:46:09.859Z"
   },
   "cd-1094-alanis-morissette-jagged-little-pill": {
     "url": "http://coverartarchive.org/release/06bb9094-75f1-4eee-a960-d5d90e5d0987/34281740844-500.jpg",
@@ -5495,14 +5495,14 @@
     "resolvedAt": "2026-03-26T18:11:10.627Z"
   },
   "cd-1099-ed-motta-dwitza": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:14:54.031Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/6a/5d/fd/6a5dfd79-875b-b655-dd4e-27daa05bb514/20UMGIM92736.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:11.366Z"
   },
   "cd-1100-ed-motta-manual-pratico-para-festas-bail": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:14:56.999Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/78/25/51/78255111-878e-ff97-8e4b-4e66c39420ab/00602435104720.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:12.905Z"
   },
   "cd-1101-ed-motta-um-contrato-com-deus": {
     "url": "http://coverartarchive.org/release/9aedacc2-0b7d-44e0-9ed2-8de7835d66bd/17776694607-500.jpg",
@@ -5512,7 +5512,7 @@
   "cd-1102-the-mount-moriah-mass-choir-the-new-age-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:04.959Z"
+    "resolvedAt": "2026-03-27T10:46:15.652Z"
   },
   "cd-1103-ana-moura-desfado": {
     "url": "http://coverartarchive.org/release/770ce7cf-e135-4094-8fc4-7cba97d869e3/4498004158-500.jpg",
@@ -5527,17 +5527,17 @@
   "cd-1105-roberto-murolo-napoletana-antologia-cron": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:15.539Z"
+    "resolvedAt": "2026-03-27T10:46:18.384Z"
   },
   "cd-1106-roberto-murolo-napoletana-volume-3-3-cds": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:17.733Z"
+    "resolvedAt": "2026-03-27T10:46:21.083Z"
   },
   "cd-1107-roberto-murolo-volume-2-1-dal-1897-al-19": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:19.659Z"
+    "resolvedAt": "2026-03-27T10:46:23.870Z"
   },
   "cd-1108-na-ozzetti-estopim": {
     "url": "http://coverartarchive.org/release/7c6e5979-2fdd-4d46-890a-4da2f1656000/22297973074-500.jpg",
@@ -5547,7 +5547,7 @@
   "cd-1109-na-ozzetti-show": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:27.951Z"
+    "resolvedAt": "2026-03-27T10:46:26.628Z"
   },
   "cd-1110-nacao-zumbi-nacao-zumbi": {
     "url": "http://coverartarchive.org/release/d69a4fd4-bf5e-4904-8d82-329ab3550820/7966428350-500.jpg",
@@ -5557,17 +5557,17 @@
   "cd-1111-nacao-zumbi-radio-s-amb-a-servico-ambula": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:35.444Z"
+    "resolvedAt": "2026-03-27T10:46:29.509Z"
   },
   "cd-1112-nara-leao-colecao-folha-50-anos-de-bossa": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:37.324Z"
+    "resolvedAt": "2026-03-27T10:46:32.470Z"
   },
   "cd-1113-nara-leao-garota-de-ipanema": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:15:39.514Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/3e/27/0c/3e270ceb-8089-34c1-8784-58900994ab07/195081143699.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:33.934Z"
   },
   "cd-1114-nat-king-cole-nat-king-cole": {
     "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/62/12/74/62127449-a912-5b5a-744f-b9cf8fbf42c4/13ULAIM54980.rgb.jpg/600x600bb.jpg",
@@ -5575,24 +5575,24 @@
     "resolvedAt": "2026-03-26T18:15:39.774Z"
   },
   "cd-1115-nat-king-cole-nat-king-cole-1-2": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:15:42.575Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/0f/19/eb/0f19eb0e-1d72-9b00-6e3b-4a8a6fca817d/18UMGIM52342.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:35.219Z"
   },
   "cd-1116-nat-king-cole-nat-king-cole-3-4": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:15:44.401Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/0f/19/eb/0f19eb0e-1d72-9b00-6e3b-4a8a6fca817d/18UMGIM52342.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:36.733Z"
   },
   "cd-1117-nat-king-cole-sweet-lorraine": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:15:46.576Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/0f/19/eb/0f19eb0e-1d72-9b00-6e3b-4a8a6fca817d/18UMGIM52342.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:37.962Z"
   },
   "cd-1118-nat-king-cole-sweet-lorraine-60-minutes-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:15:48.489Z"
+    "resolvedAt": "2026-03-27T10:46:40.660Z"
   },
   "cd-1119-nat-king-cole-the-best-of-the-nat-king-c": {
     "url": "http://coverartarchive.org/release/c4359f4a-37a7-483b-bf97-edf05d2d7a4d/37678373107-500.jpg",
@@ -5605,19 +5605,19 @@
     "resolvedAt": "2026-03-26T18:15:56.576Z"
   },
   "cd-1121-nat-king-cole-the-very-thought-of-you": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:15:58.641Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/0b/6e/55/0b6e554e-ff02-5546-dae3-0465745b698a/05099921383854.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:41.956Z"
   },
   "cd-1122-natalie-cole-unforgettable": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:16:01.756Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/07/04/82/07048202-a054-8c3f-7c3e-8d8a286c71cc/19CRGIM10645.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:43.291Z"
   },
   "cd-1123-nelson-rufino-a-verdade": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:16:03.639Z"
+    "resolvedAt": "2026-03-27T10:46:46.055Z"
   },
   "cd-1124-aaron-neville-warm-your-heart": {
     "url": "http://coverartarchive.org/release/360430df-e255-4649-82b2-acb70841f8a4/14910198371-500.jpg",
@@ -5630,14 +5630,14 @@
     "resolvedAt": "2026-03-26T18:16:11.887Z"
   },
   "cd-1126-new-york-voices-sing-the-songs-of-paul-s": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:16:13.972Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/39/e8/5c/39e85c62-83f6-cced-9a56-122f2361566e/dj.jicohfwb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:47.305Z"
   },
   "cd-1127-neymar-dias-igor-pimenta-come-together-p": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:16:15.898Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music1/v4/01/df/11/01df11fc-630d-8647-a270-ec2726f39dee/7898538180249.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:48.756Z"
   },
   "cd-1128-nicholas-payton-doc-cheatham-nicholas-pa": {
     "url": "http://coverartarchive.org/release/c2763627-786c-40c8-b57f-b61c7c2076b1/28600691135-500.jpg",
@@ -5655,9 +5655,9 @@
     "resolvedAt": "2026-03-26T18:16:29.429Z"
   },
   "cd-1131-nicholas-payton-nick-night": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:16:31.439Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/38/6c/cf/386ccfa2-5703-0cec-f25e-9fbd58e721b0/00731454759823.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:50.065Z"
   },
   "cd-1132-nicholas-payton-payton-s-place": {
     "url": "http://coverartarchive.org/release/1adaa657-f85f-4a32-9a56-b5385e7f5cda/16378889983-500.jpg",
@@ -5667,7 +5667,7 @@
   "cd-1133-nilson-chaves-e-vital-lima-waldemar": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:16:38.073Z"
+    "resolvedAt": "2026-03-27T10:46:53.195Z"
   },
   "cd-1134-nnenna-freelon-heritage": {
     "url": "http://coverartarchive.org/release/7159f164-7875-4f7e-8abf-66e3f603b1bb/16776295793-500.jpg",
@@ -5680,44 +5680,44 @@
     "resolvedAt": "2026-03-26T18:16:46.731Z"
   },
   "cd-1136-noel-rosa-coisas-nossas": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:16:48.803Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music18/v4/8f/74/44/8f74449d-d981-d122-c934-f75e39a3fa7d/mzm.wcvbpoml.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:55.290Z"
   },
   "cd-1137-noel-rosa-colecao-folha-raizes-da-musica": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:16:50.717Z"
+    "resolvedAt": "2026-03-27T10:46:58.505Z"
   },
   "cd-1138-noel-rosa-mpb-compositores-noel-rosa": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:16:52.574Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/d4/fc/06/d4fc0640-1414-0677-9bdd-5d4c4c81805b/1963621408220_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:46:59.902Z"
   },
   "cd-1139-noel-rosa-noel-pela-primeira-vez": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:16:54.464Z"
+    "resolvedAt": "2026-03-27T10:47:02.678Z"
   },
   "cd-1140-nora-ney-expedito-baracho-dalva-torres-c": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:16:56.356Z"
+    "resolvedAt": "2026-03-27T10:47:05.442Z"
   },
   "cd-1141-claude-nougaro-vol-1-vol-2": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:16:58.734Z"
+    "resolvedAt": "2026-03-27T10:47:08.278Z"
   },
   "cd-1142-nouvelle-cuisine-free-bossa": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:17:01.585Z"
+    "resolvedAt": "2026-03-27T10:47:11.365Z"
   },
   "cd-1143-nouvelle-cuisine-nouvelle-cuisine": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:03.477Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/25/e1/8d/25e18dc5-895c-a6ae-df34-05e76cfe3932/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:12.673Z"
   },
   "cd-1144-nouvelle-cuisine-slow-food": {
     "url": "http://coverartarchive.org/release/fcf52799-7bf8-4fb0-bded-f27e19d52fc3/22108786680-500.jpg",
@@ -5725,54 +5725,54 @@
     "resolvedAt": "2026-03-26T18:17:08.497Z"
   },
   "cd-1145-lucila-novaes-frestas-de-ceu": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:10.517Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/23/e9/e7/23e9e779-2c48-8afd-94f1-6d4055323a1c/0632627957957.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:13.996Z"
   },
   "cd-1146-novos-baianos-acabou-chorare": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:12.979Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/81/f0/78/81f0780b-c2d5-52bd-d80e-0c429eeebc36/196873466569.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:15.296Z"
   },
   "cd-1147-nueva-manteca-in-concert-at-nick-vollebr": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:14.964Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/52/f5/60/52f56068-1b77-1ab4-e074-7b3b6ea1639a/859703545116.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:16.562Z"
   },
   "cd-1148-nuyorican-soul-nuyorican-soul": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:17.119Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/8a/d8/e6/8ad8e6f7-2783-4375-6ee9-59643f9737e5/00602517142695.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:17.801Z"
   },
   "cd-1149-o-rappa-lado-b-lado-a": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:19.211Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/d6/1b/b4/mzi.bsprrwtu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:19.136Z"
   },
   "cd-1150-earl-okin-musical-genius-sex-symbol": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:21.510Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/df/60/c8/mzi.lrqpebxq.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:20.542Z"
   },
   "cd-1151-jose-oliveira-romance-de-amor": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:17:23.345Z"
+    "resolvedAt": "2026-03-27T10:47:23.456Z"
   },
   "cd-1152-original-soundtrack-bagdad-cafe": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:25.301Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/6a/8c/99/6a8c99b1-94e6-be9c-3cb1-6e8e03dc3a70/196626355935.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:24.778Z"
   },
   "cd-1153-orlando-silva-o-cantor-das-multidoes": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:30.002Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/cf/c6/5d/cfc65dfc-afc2-cffc-b835-f71501fd6ac5/886447407035.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:26.083Z"
   },
   "cd-1154-ornella-vanoni-enrico-ruggeri-ornella-va": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:17:32.063Z"
+    "resolvedAt": "2026-03-27T10:47:29.244Z"
   },
   "cd-1155-ornette-coleman-double-quartet-free-jazz": {
     "url": "http://coverartarchive.org/release/204968d5-4394-445f-a5ad-9ea36de63a69/15535624485-500.jpg",
@@ -5780,9 +5780,9 @@
     "resolvedAt": "2026-03-26T18:17:36.806Z"
   },
   "cd-1156-ornette-coleman-joachim-kuhn-colors": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:38.895Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/9d/d7/2e/9dd72efb-f0fa-5d15-a850-eb99383f0e04/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:30.559Z"
   },
   "cd-1157-orquestra-imperial-carnaval-so-ano-que-v": {
     "url": "http://coverartarchive.org/release/270a8bac-6a12-4c5a-93c7-e3d17fc96665/2876164719-500.jpg",
@@ -5790,19 +5790,19 @@
     "resolvedAt": "2026-03-26T18:17:43.287Z"
   },
   "cd-1158-orquestra-popular-de-camara-dancas-jogos": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:45.724Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/2b/17/fd/2b17fd46-2b2c-8bd1-867d-caa455b49112/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:31.799Z"
   },
   "cd-1159-orquestra-sinfonica-de-campinas-episodio": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:17:47.562Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/39/2c/e8/392ce8b0-5214-370e-f144-ab1cf5e53433/00028943989626.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:33.130Z"
   },
   "cd-1160-orquestra-sinfonica-municipal-de-sao-pau": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:17:49.422Z"
+    "resolvedAt": "2026-03-27T10:47:35.934Z"
   },
   "cd-1161-oscar-peterson-a-tribute-to-oscar-peters": {
     "url": "http://coverartarchive.org/release/02e4cec9-d7b5-48d6-9524-fec96a91cfce/33694496030-500.jpg",
@@ -5817,7 +5817,7 @@
   "cd-1163-oscar-pettiford-deep-passion": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:18:01.876Z"
+    "resolvedAt": "2026-03-27T10:47:40.093Z"
   },
   "cd-1164-outkast-stankonia": {
     "url": "http://coverartarchive.org/release/296f8a54-eff7-3c6a-9857-164c05479c09/24569780625-500.jpg",
@@ -5827,7 +5827,7 @@
   "cd-1165-paulo-padilha-cara-legal": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:18:08.467Z"
+    "resolvedAt": "2026-03-27T10:47:42.775Z"
   },
   "cd-1166-palavra-cantada-cancoes-curiosas": {
     "url": "https://coverartarchive.org/release/a5cd1df6-3eec-4aaa-b88f-49b97d317e18/18382686698-500.jpg",
@@ -5835,9 +5835,9 @@
     "resolvedAt": "2026-03-26T18:18:13.216Z"
   },
   "cd-1167-palavra-cantada-mil-passaros-sete-histor": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:18:15.497Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/aa/4e/94/aa4e9446-a9a6-7b2c-b992-6df4a48e3fec/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:44.940Z"
   },
   "cd-1168-palavra-cantada-pe-com-pe": {
     "url": "https://coverartarchive.org/release/dd6e8392-192e-4f71-9651-ec576ce73a66/41048100493-500.jpg",
@@ -5855,9 +5855,9 @@
     "resolvedAt": "2026-03-26T18:18:27.747Z"
   },
   "cd-1171-os-paralamas-do-sucesso-vamo-bate-lata-d": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:18:30.519Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/85/13/70/851370bd-df7d-b496-6b90-bf9552c1c30b/00602567112136.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:46.366Z"
   },
   "cd-1172-charlie-parker-charlie-parker": {
     "url": "http://coverartarchive.org/release/fcbd6f14-b20c-4720-9086-c359c45e6101/28598223854-500.jpg",
@@ -5880,9 +5880,9 @@
     "resolvedAt": "2026-03-26T18:18:47.659Z"
   },
   "cd-1176-passport-doldinger": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:18:51.750Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/ef/59/67/ef596741-d90a-365a-ec60-d974cef503bd/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:47.685Z"
   },
   "cd-1177-jaco-pastorius-jaco-pastorius": {
     "url": "http://coverartarchive.org/release/8f161142-a8fe-4610-9aec-52118b902cbb/34517577014-500.jpg",
@@ -5900,9 +5900,9 @@
     "resolvedAt": "2026-03-26T18:19:05.970Z"
   },
   "cd-1180-pat-metheny-works-ii": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:08.276Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/93/5c/0a/935c0aac-08af-4d04-b006-6054d7aae930/00042283727229.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:49.028Z"
   },
   "cd-1181-pat-metheny-group-letter-from-home": {
     "url": "http://coverartarchive.org/release/3a48d210-22ed-4728-af46-1935f9adf718/14417517023-500.jpg",
@@ -5910,9 +5910,9 @@
     "resolvedAt": "2026-03-26T18:19:12.749Z"
   },
   "cd-1182-pat-metheny-ornette-coleman-song-x": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:14.946Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/5f/06/3b/5f063b2f-f184-624a-7ff7-5ee5cd50b635/75597991864.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:50.289Z"
   },
   "cd-1183-patricia-barber-companion": {
     "url": "http://coverartarchive.org/release/32dd9da1-f858-4f1b-b7df-35b839e2f9ed/12266488376-500.jpg",
@@ -5920,9 +5920,9 @@
     "resolvedAt": "2026-03-26T18:19:19.219Z"
   },
   "cd-1184-patricia-barber-night-club": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:21.200Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/8c/42/dd/8c42ddc7-4f4f-ce64-17e4-cc0556e3777c/193483203904_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:51.599Z"
   },
   "cd-1185-paul-desmond-late-lament": {
     "url": "http://coverartarchive.org/release/4a9f9939-d8df-46dc-990c-67573e1a0031/8866888389-500.jpg",
@@ -5930,9 +5930,9 @@
     "resolvedAt": "2026-03-26T18:19:25.658Z"
   },
   "cd-1186-paul-motian-2000-one": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:28.178Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/72/39/b9/7239b9a3-290e-2a08-0eee-d664b16b17d2/025091003228.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:52.898Z"
   },
   "cd-1187-paul-motian-motian-in-tokyo": {
     "url": "http://coverartarchive.org/release/84a2c990-3f1b-4221-851e-9471f77eff70/7684219192-500.jpg",
@@ -5945,9 +5945,9 @@
     "resolvedAt": "2026-03-26T18:19:35.827Z"
   },
   "cd-1189-paulo-lepetit-le-petit-comite": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:37.787Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/25/2d/2a/252d2a6c-9a1c-1c71-a423-701a8ddb1d16/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:54.241Z"
   },
   "cd-1190-luciano-pavarotti-tutto-pavarotti": {
     "url": "http://coverartarchive.org/release/f350393e-2459-44c5-ae1b-cb71534780f3/8910264869-500.jpg",
@@ -5960,14 +5960,14 @@
     "resolvedAt": "2026-03-26T18:19:45.693Z"
   },
   "cd-1192-pedro-mariano-voz-no-ouvido": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:47.606Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/5d/6b/17/5d6b174c-1e1d-2d5e-514c-7d55067d2ede/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:47:55.499Z"
   },
   "cd-1193-peggy-lee-close-enough-for-love": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:19:50.320Z"
+    "resolvedAt": "2026-03-27T10:47:59.865Z"
   },
   "cd-1194-ivo-perelman-children-of-ibeji": {
     "url": "https://coverartarchive.org/release/e03010a3-0355-4570-a838-cac142c50c55/42877814216-500.jpg",
@@ -5975,9 +5975,9 @@
     "resolvedAt": "2026-03-26T18:19:55.397Z"
   },
   "cd-1195-pete-laroca-basra": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:19:57.546Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/3a/4b/79/3a4b79db-cb29-95ea-6b27-b06e411b05fe/00724386447753.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:01.186Z"
   },
   "cd-1196-peter-delano-bite-of-the-apple": {
     "url": "http://coverartarchive.org/release/bbacccf6-d5d3-4f0c-b019-5259ce171775/21524825368-500.jpg",
@@ -5990,9 +5990,9 @@
     "resolvedAt": "2026-03-26T18:20:05.823Z"
   },
   "cd-1198-astor-piazzolla-gary-burton-il-pleut-sur": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:20:07.775Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music5/v4/c3/2e/ca/c32ecaa7-e832-5b88-f4e7-5332fe7c1d32/886444855334.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:02.433Z"
   },
   "cd-1199-pink-floyd-the-dark-side-of-the-moon": {
     "url": "https://coverartarchive.org/release/be701edc-c9c7-484a-9ed2-aeef051c19be/13160495709-500.jpg",
@@ -6000,9 +6000,9 @@
     "resolvedAt": "2026-03-26T18:20:12.235Z"
   },
   "cd-1200-pink-floyd-the-dark-side-of-the-moon-imm": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:20:14.312Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/0b/5b/66/0b5b6697-9d7e-86aa-1971-7a370d6b1d34/859744553750_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:03.751Z"
   },
   "cd-1201-the-platters-the-platters": {
     "url": "https://coverartarchive.org/release/bca5cb03-3e2f-4438-8e7a-96b6bf9ab1a6/38676805066-500.jpg",
@@ -6027,17 +6027,17 @@
   "cd-1205-zizi-possi-millennium-20-musicas-do-secu": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:20:32.592Z"
+    "resolvedAt": "2026-03-27T10:48:06.624Z"
   },
   "cd-1206-zizi-possi-passione": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:20:34.770Z"
+    "resolvedAt": "2026-03-27T10:48:09.895Z"
   },
   "cd-1207-zizi-possi-per-amore": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:20:36.971Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/e3/b8/01/e3b801af-4406-7f5b-6026-a7e4ec56992b/06UMGIM60390.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:11.315Z"
   },
   "cd-1208-zizi-possi-sobre-todas-as-coisas": {
     "url": "http://coverartarchive.org/release/072f1750-784e-477e-a8a5-80906d653de7/20213469276-500.jpg",
@@ -6047,12 +6047,12 @@
   "cd-1209-baden-powell-colecao-folha-50-anos-de-bo": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:20:43.599Z"
+    "resolvedAt": "2026-03-27T10:48:14.083Z"
   },
   "cd-1210-preservation-hall-jazz-band-best-of-pres": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:20:45.771Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features2/v4/00/1e/72/001e7236-5066-c2af-9cc4-a9c75ecd280a/dj.xkllaboj.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:15.334Z"
   },
   "cd-1211-elvis-presley-born-to-be-king": {
     "url": "http://coverartarchive.org/release/8e2bae79-19ac-4e7b-9bae-a4257cadc1e2/1552126452-500.jpg",
@@ -6060,9 +6060,9 @@
     "resolvedAt": "2026-03-26T18:20:50.383Z"
   },
   "cd-1212-preta-gil-medida-do-amor": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:20:52.626Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/a3/a8/52/a3a852a4-5d84-d3c9-5642-b53fc8444da6/195081541921.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:16.598Z"
   },
   "cd-1213-pride-of-lions-pride-of-lions": {
     "url": "http://coverartarchive.org/release/bc97b2d7-9dee-4c25-876f-c65349a638e3/15164842691-500.jpg",
@@ -6085,29 +6085,29 @@
     "resolvedAt": "2026-03-26T18:21:12.010Z"
   },
   "cd-1217-prince-the-new-power-generation-diamonds": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:21:13.858Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/ef/18/77/ef18776a-d99a-d16e-ee75-601ed8c03c1d/886448900085.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:17.871Z"
   },
   "cd-1218-giacomo-puccini-colecao-folha-grandes-op": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:21:15.752Z"
+    "resolvedAt": "2026-03-27T10:48:20.708Z"
   },
   "cd-1219-pyotr-ilyich-tchaikovsky-oskar-fried-the": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:21:17.592Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features114/v4/ef/df/b7/efdfb713-2935-0dfc-05e0-bbbe3a2daf8d/dj.aomjdzqh.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:22.020Z"
   },
   "cd-1220-quarteto-em-cy-mpb-4-bate-boca": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:21:19.597Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/f9/d8/47/f9d8471a-d7ee-af45-86c4-a62d4669d8f7/00602577532498.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:23.260Z"
   },
   "cd-1221-quarteto-livre-pra-que-mentir": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:21:21.736Z"
+    "resolvedAt": "2026-03-27T10:48:25.944Z"
   },
   "cd-1222-queen-greatest-hits-ii": {
     "url": "http://coverartarchive.org/release/bbcd726c-fa5e-4de1-8fd3-d76d581619c7/11210813594-500.jpg",
@@ -6117,17 +6117,17 @@
   "cd-1223-quinteto-de-sopros-de-curitiba-quinteto-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:21:28.792Z"
+    "resolvedAt": "2026-03-27T10:48:28.655Z"
   },
   "cd-1224-quinteto-vento-em-madeira-brasiliana": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:21:30.839Z"
+    "resolvedAt": "2026-03-27T10:48:31.827Z"
   },
   "cd-1225-quinteto-vento-em-madeira-quinteto-vento": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:21:32.724Z"
+    "resolvedAt": "2026-03-27T10:48:34.980Z"
   },
   "cd-1226-rachel-z-room-of-one-s-own": {
     "url": "http://coverartarchive.org/release/03445d5a-7b28-4380-ace2-3291ef51833b/32766454221-500.jpg",
@@ -6140,14 +6140,14 @@
     "resolvedAt": "2026-03-26T18:21:42.442Z"
   },
   "cd-1228-corinne-bailey-rae-corinne-bailey-rae": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:21:44.666Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/d9/cd/24/d9cd2461-82dc-9f9f-6ed3-86bb75d110b9/13UABIM50290.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:36.369Z"
   },
   "cd-1229-ramsey-lewis-a-jazz-hour-with-the-ramsey": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:21:46.581Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/f6/5b/d6/f65bd650-6232-9490-b1fa-494422bde6da/06UMGIM16093.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:37.653Z"
   },
   "cd-1230-ramsey-lewis-ivory-pyramid": {
     "url": "http://coverartarchive.org/release/06cb641f-9a44-4d22-b4aa-9974fb7a8f35/15408672038-500.jpg",
@@ -6157,7 +6157,7 @@
   "cd-1231-ran-blake-jeanne-lee-you-stepped-out-of-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:21:52.987Z"
+    "resolvedAt": "2026-03-27T10:48:40.462Z"
   },
   "cd-1232-raquel-coutinho-olho-d-agua": {
     "url": "http://coverartarchive.org/release/fc8a57dc-0882-42f7-af3b-271130fab390/11946221494-500.jpg",
@@ -6165,9 +6165,9 @@
     "resolvedAt": "2026-03-26T18:21:57.994Z"
   },
   "cd-1233-ravel-maurice-ma-mere-l-oye-daphne-et-ch": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:22:00.081Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/ff/b1/60/mzi.stybbncu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:41.997Z"
   },
   "cd-1234-ravi-coltrane-from-the-round-box": {
     "url": "http://coverartarchive.org/release/60ceddb9-33cd-30cd-95d9-fc82421196bc/4440438914-500.jpg",
@@ -6180,14 +6180,14 @@
     "resolvedAt": "2026-03-26T18:22:09.762Z"
   },
   "cd-1236-ray-charles-best-of-ray-charles-atlantic": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:22:11.931Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/e4/2c/fb/e42cfb89-6e07-1c5c-5271-b49c78438de7/dj.ueeuybev.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:43.321Z"
   },
   "cd-1237-ray-charles-early-years": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:22:16.450Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/ce/fe/35/cefe35f5-be87-0d3b-a9d4-ad6e1d0fa58a/dj.buborpbo.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:44.666Z"
   },
   "cd-1238-ray-charles-genius-soul-jazz": {
     "url": "http://coverartarchive.org/release/62667826-308f-49c1-b9a9-d05b165f95b7/23718380016-500.jpg",
@@ -6205,14 +6205,14 @@
     "resolvedAt": "2026-03-26T18:22:29.484Z"
   },
   "cd-1241-ray-charles-cleo-laine-porgy-bess": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:22:31.319Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/03/71/44/0371445c-202a-4ec3-3970-f4e357d0299b/OTLCD2462.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:45.912Z"
   },
   "cd-1242-margareth-reali-onde-o-ceu-azul-e-mais-a": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:22:33.222Z"
+    "resolvedAt": "2026-03-27T10:48:48.705Z"
   },
   "cd-1243-red-hot-chili-peppers-californication": {
     "url": "http://coverartarchive.org/release/d42e8186-d02f-4fab-a525-0fa2d8ab8631/4585942624-500.jpg",
@@ -6220,14 +6220,14 @@
     "resolvedAt": "2026-03-26T18:22:37.405Z"
   },
   "cd-1244-otis-redding-the-dock-of-the-bay-the-def": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:22:39.245Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/90/10/ec/9010eccf-abce-ae23-5d37-c8610dd63d4b/08UMGIM16458.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:50.026Z"
   },
   "cd-1245-banda-reflexus-atlantida": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:22:41.125Z"
+    "resolvedAt": "2026-03-27T10:48:52.801Z"
   },
   "cd-1246-regina-carter-motor-city-moments": {
     "url": "http://coverartarchive.org/release/328783ef-221d-4d0b-8fd9-f97ad9095a62/28977291158-500.jpg",
@@ -6240,9 +6240,9 @@
     "resolvedAt": "2026-03-26T18:22:49.908Z"
   },
   "cd-1248-elis-regina-elis-essa-mulher": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:22:52.549Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/v4/4e/ea/f7/4eeaf7bf-2c85-2d75-ec42-91201ab86fcb/dj.yswllmbg.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:48:54.126Z"
   },
   "cd-1249-elis-regina-falso-brilhante": {
     "url": "http://coverartarchive.org/release/3c970a30-0782-47c1-8e4f-f2c290ed423c/10167147348-500.jpg",
@@ -6257,27 +6257,27 @@
   "cd-1251-elis-regina-personalidade-cd2": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:04.709Z"
+    "resolvedAt": "2026-03-27T10:48:57.108Z"
   },
   "cd-1252-renato-consorte-renato-luiz-consorte-e-r": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:06.644Z"
+    "resolvedAt": "2026-03-27T10:48:59.994Z"
   },
   "cd-1253-rene-marie-how-can-i-keep-from-singing": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:08.786Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/8b/1a/84/8b1a84a6-4c26-08ac-0582-39e5ab272efd/190374204941.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:01.254Z"
   },
   "cd-1254-ricardo-herz-herz-e-loureiro": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:10.684Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/44/22/ca/4422ca74-cb27-55ae-6b4f-c470b920dbc3/7898538180225.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:02.598Z"
   },
   "cd-1255-richard-groove-holmes-plenty-plenty-blue": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:13.345Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/4e/09/a6/4e09a6f2-a41d-8d39-a694-c17cfddf335f/00724353870157.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:04.010Z"
   },
   "cd-1256-rio-65-trio-rio-65-trio": {
     "url": "http://coverartarchive.org/release/a3bff85b-c628-41ee-a159-978f40c64128/7243916167-500.jpg",
@@ -6287,12 +6287,12 @@
   "cd-1257-rio65trio-a-hora-e-vez-da-mpm": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:20.033Z"
+    "resolvedAt": "2026-03-27T10:49:06.808Z"
   },
   "cd-1258-rita-coolige-out-of-the-blues": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:21.960Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/ea/89/8d/ea898dc7-79a3-f8c7-fdcd-8fed21bf9973/mzi.fyjtoqdz.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:08.072Z"
   },
   "cd-1259-maria-rita-elo": {
     "url": "https://coverartarchive.org/release/724c69c2-7f94-42ac-8931-f7588b3385c8/43741513039-500.jpg",
@@ -6302,7 +6302,7 @@
   "cd-1260-johnny-rivers-meus-momentos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:28.869Z"
+    "resolvedAt": "2026-03-27T10:49:10.921Z"
   },
   "cd-1261-robben-ford-blues-connotation": {
     "url": "http://coverartarchive.org/release/2765d682-4521-4672-ba93-5d94e17dde6e/9202152401-500.jpg",
@@ -6310,14 +6310,14 @@
     "resolvedAt": "2026-03-26T18:23:33.255Z"
   },
   "cd-1262-robert-hurst-one-for-namesake": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:35.547Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/31/f9/7b/mzi.aaodsebo.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:12.152Z"
   },
   "cd-1263-robert-hurst-robert-hurst-presents-rober": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:37.511Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/22/7e/bd/mzi.mmdxfncp.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:13.402Z"
   },
   "cd-1264-roberta-sa-trio-madeira-brasil-quando-o-": {
     "url": "http://coverartarchive.org/release/d006e1c9-ca5a-4b7a-99b0-bd60121a4315/5657339059-500.jpg",
@@ -6327,32 +6327,32 @@
   "cd-1265-ulisses-rocha-album": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:45.240Z"
+    "resolvedAt": "2026-03-27T10:49:20.033Z"
   },
   "cd-1266-ulisses-rocha-fractal": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:47.391Z"
+    "resolvedAt": "2026-03-27T10:49:23.462Z"
   },
   "cd-1267-rodney-kendrick-we-don-t-die-we-multipli": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:49.272Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/1b/2f/2c/1b2f2c44-bd7b-56d4-bfe3-13d7af0bbdf1/00731453744721.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:24.897Z"
   },
   "cd-1268-rofolfo-stroeter-tytty-moreno-andre-mehm": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:23:51.279Z"
+    "resolvedAt": "2026-03-27T10:49:27.635Z"
   },
   "cd-1269-rogerio-botter-maio-aprendiz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:53.241Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/80/53/dd/mzi.lsquohup.tif/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:28.887Z"
   },
   "cd-1270-rogerio-botter-maio-tudo-por-um-ocaso": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:23:55.075Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/a7/29/88/mzi.pjpsqgis.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:30.211Z"
   },
   "cd-1271-the-rolling-stones-voodoo-lounge": {
     "url": "http://coverartarchive.org/release/bbe6830c-7a4d-4866-baf3-69a056527ee7/10082983125-500.jpg",
@@ -6365,19 +6365,19 @@
     "resolvedAt": "2026-03-26T18:24:06.516Z"
   },
   "cd-1273-virginia-rosa-virginia-rosa": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:08.570Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/f7/d2/d5/f7d2d52a-393f-c626-080b-d2634e5464f0/artwork.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:31.524Z"
   },
   "cd-1274-diana-ross-diana-ross-30-anos": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:10.406Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/e0/45/42/e04542ac-f078-2f00-5395-80f1b7cae5dc/07UMGIM04751.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:32.788Z"
   },
   "cd-1275-nino-rota-greatest-hits": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:12.535Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music6/v4/65/4f/01/654f0126-ab0c-8b0b-455f-bb6206ff26de/886444196789.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:34.056Z"
   },
   "cd-1276-roy-hargrove-family": {
     "url": "http://coverartarchive.org/release/7454302b-fa4b-439f-97a6-28f698b2e01f/5836908987-500.jpg",
@@ -6400,9 +6400,9 @@
     "resolvedAt": "2026-03-26T18:24:24.729Z"
   },
   "cd-1280-roy-hargrove-christian-mcbride-stephen-s": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:26.613Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/26/94/23/26942301-26f7-2330-14b1-a19e45f3ef1d/00731452790729.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:35.412Z"
   },
   "cd-1281-roy-orbison-and-friends-a-black-and-whit": {
     "url": "http://coverartarchive.org/release/c788f106-1e47-45e0-89e1-fb5063b9bdd4/23968155304-500.jpg",
@@ -6410,124 +6410,124 @@
     "resolvedAt": "2026-03-26T18:24:31.219Z"
   },
   "cd-1282-the-royal-philharmonic-orchestra-plays-d": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:33.341Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/b7/8b/ab/b78babe3-412a-a4b7-0d32-0fc55880785e/mzi.mkrnekdw.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:36.677Z"
   },
   "cd-1283-royal-philharmonic-orchestra-antonin-dvo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:35.184Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/65/b1/be/65b1bef3-309c-e3e0-332b-79b6d3266a71/191773014100.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:37.926Z"
   },
   "cd-1284-royal-philharmonic-orchestra-antonio-car": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:37.130Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/a9/7f/2a/mzi.bderkflr.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:39.164Z"
   },
   "cd-1285-royal-philharmonic-orchestra-antonio-viv": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:38.975Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/eb/92/3a/mzi.xgambhhu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:40.508Z"
   },
   "cd-1286-royal-philharmonic-orchestra-felix-mende": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:40.806Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/45/2c/a6/452ca681-a499-074e-e74a-836aef318301/26UMGIM12738.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:42.104Z"
   },
   "cd-1287-royal-philharmonic-orchestra-frederic-ch": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:42.798Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2b/79/85/2b798553-564b-f84e-2d9c-a1892dea1106/21UMGIM67559.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:43.564Z"
   },
   "cd-1288-royal-philharmonic-orchestra-george-gers": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:44.709Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/fc/0d/86/mzi.yzokerby.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:44.955Z"
   },
   "cd-1289-royal-philharmonic-orchestra-georges-biz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:46.599Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/91/f5/6d/91f56d72-f002-5cc3-02ac-4b88883faef8/886446463087.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:46.468Z"
   },
   "cd-1290-royal-philharmonic-orchestra-gioacchino-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:48.475Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/db/cc/a7/dbcca775-6317-d592-208c-0f983a5dabba/3149020943960_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:47.798Z"
   },
   "cd-1291-royal-philharmonic-orchestra-gustav-mahl": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:50.315Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/3a/fe/d0/3afed08a-0fa6-56d6-0684-2c8729cca8d8/00028943778923.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:49.165Z"
   },
   "cd-1292-royal-philharmonic-orchestra-hector-berl": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:52.196Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/92/16/d5/dj.kcnnwvpu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:50.438Z"
   },
   "cd-1293-royal-philharmonic-orchestra-igor-stravi": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:54.091Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/ce/40/5d/ce405d2a-62de-24ca-75d2-53f36c6f3a8d/886446440644.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:51.752Z"
   },
   "cd-1294-royal-philharmonic-orchestra-johann-seba": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:55.977Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/eb/92/3a/mzi.xgambhhu.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:53.386Z"
   },
   "cd-1295-royal-philharmonic-orchestra-johannes-br": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:57.894Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/1c/93/5b/1c935b0a-7a40-6441-7eaf-9d81ccf76e68/00028947426325.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:54.729Z"
   },
   "cd-1296-royal-philharmonic-orchestra-joseph-hayd": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:24:59.775Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/70/c4/c3/70c4c364-370d-b8ea-8555-fb0ab5a18172/4260716431918_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:56.008Z"
   },
   "cd-1297-royal-philharmonic-orchestra-leonard-ber": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:01.656Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/71/b1/ec/71b1ec21-b3a7-9e2f-52c2-c37ef2155dea/21UM1IM43161.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:57.313Z"
   },
   "cd-1298-royal-philharmonic-orchestra-ludwig-van-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:03.565Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/cd/ba/95/cdba95d2-3d26-ed68-9a32-511dd5547a79/26UMGIM04384.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:58.629Z"
   },
   "cd-1299-royal-philharmonic-orchestra-nikolai-rim": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:05.458Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/7b/28/7a/mzi.wrckuzff.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:49:59.880Z"
   },
   "cd-1300-royal-philharmonic-orchestra-pyotr-ilyic": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:07.403Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/02/ab/88/02ab8825-ed55-2fdd-f597-6995fd568a6f/886788975637.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:01.251Z"
   },
   "cd-1301-royal-philharmonic-orchestra-richard-str": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:09.337Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/e4/cc/44/e4cc44ec-3c98-431d-9556-117727feb702/06UMGIM52158.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:02.597Z"
   },
   "cd-1302-royal-philharmonic-orchestra-richard-wag": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:11.180Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/26/8e/24/268e2456-a5d0-0c70-3bd1-8a23a4b4d5f8/5906395034321.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:03.858Z"
   },
   "cd-1303-royal-philharmonic-orchestra-robert-schu": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:13.123Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/1c/a7/33/1ca73367-523f-b793-dd18-9c2c7604e726/00028944552225.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:05.216Z"
   },
   "cd-1304-royal-philharmonic-orchestra-sergei-prok": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:15.011Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/v4/9c/c2/30/9cc23092-31ce-7dbe-1d45-b53ee29baaf9/V4HttpAssetRepositoryClient-ticket.laposvqt.jpg-823594534214097826.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:06.564Z"
   },
   "cd-1305-royal-philharmonic-orchestra-wolfgang-am": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:16.857Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/e1/25/d1/e125d139-067d-b01b-052d-935c8da640fc/26UMGIM04499.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:08.305Z"
   },
   "cd-1306-enrico-ruggeri-domani-e-un-altro-giorno": {
     "url": "http://coverartarchive.org/release/2b3b7350-d51b-40ad-bd1b-199da1ee7ee0/1624109691-500.jpg",
@@ -6535,9 +6535,9 @@
     "resolvedAt": "2026-03-26T18:25:21.598Z"
   },
   "cd-1307-sa-guarabyra-focus-o-essencial-de-sa-gua": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:23.668Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/c9/55/bd/c955bd86-2038-7140-c90f-0ae29d0b8f49/196874199770.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:10.124Z"
   },
   "cd-1308-ryuichi-sakamoto-smoochy": {
     "url": "https://coverartarchive.org/release/94353e0a-42cf-4dfc-a7cd-1a96d5094235/27327336243-500.jpg",
@@ -6545,14 +6545,14 @@
     "resolvedAt": "2026-03-26T18:25:28.409Z"
   },
   "cd-1309-sandy-manuscrito": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:30.715Z"
+    "url": "http://coverartarchive.org/release/69a933bb-f41a-476d-a892-b0248cef10f6/14116749590-500.jpg",
+    "source": "coverart",
+    "resolvedAt": "2026-03-27T10:50:17.428Z"
   },
   "cd-1310-sandy-junior-acustico-mtv": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:32.557Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/05/8f/1f/058f1f84-24a3-9f19-c021-fbc32a3e2def/15UMGIM32329.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:19.160Z"
   },
   "cd-1311-ivete-sangalo-mtv-ao-vivo": {
     "url": "http://coverartarchive.org/release/767f8859-64a3-4829-bc3d-836ee3e44462/17702702196-500.jpg",
@@ -6560,9 +6560,9 @@
     "resolvedAt": "2026-03-26T18:25:37.162Z"
   },
   "cd-1312-ivete-sangalo-multishow-ao-vivo-ivete-sa": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:25:39.203Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/22/fe/03/22fe0300-bb65-11c0-e1d1-e75eefada87c/07UMGIM11579.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:20.472Z"
   },
   "cd-1313-santana-supernatural": {
     "url": "https://coverartarchive.org/release/85c5184e-bffc-4263-80ba-6aa460533f9f/38931028213-500.jpg",
@@ -6572,7 +6572,7 @@
   "cd-1314-lulu-santos-acustico-mtv-disco-1": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:25:45.521Z"
+    "resolvedAt": "2026-03-27T10:50:23.247Z"
   },
   "cd-1315-lulu-santos-anti-ciclone-tropical": {
     "url": "http://coverartarchive.org/release/cc9ddfd6-b595-4a24-bbeb-eb6a6e25d0ae/35344932785-500.jpg",
@@ -6605,34 +6605,34 @@
     "resolvedAt": "2026-03-26T18:26:10.384Z"
   },
   "cd-1321-sarah-vaughan-clifford-brown-sarah-vaugh": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:26:12.460Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/2e/ab/51/2eab51c2-0da6-18f7-4796-674871ee58b4/06UMGIM17900.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:24.524Z"
   },
   "cd-1322-gabriel-sater-indomavel": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:26:14.294Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/66/d0/2f/66d02fed-fdbf-6244-e7cd-f44f9891adae/8720693295638.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:25.795Z"
   },
   "cd-1323-tito-schipa-his-first-records": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:26:16.141Z"
+    "resolvedAt": "2026-03-27T10:50:28.520Z"
   },
   "cd-1324-tito-schipa-the-best-of-victor-and-hmv-r": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:26:17.977Z"
+    "resolvedAt": "2026-03-27T10:50:31.223Z"
   },
   "cd-1325-scott-hamilton-scott-hamilton-plays-ball": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:26:20.061Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/94/bd/66/94bd66cc-91f7-322b-1fd2-8968eee484b9/00013431438625.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:32.639Z"
   },
   "cd-1326-sefon-harris-savid-sanchez-christian-sco": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:26:21.951Z"
+    "resolvedAt": "2026-03-27T10:50:35.402Z"
   },
   "cd-1327-semisonic-feeling-strangely-fine": {
     "url": "http://coverartarchive.org/release/3990d868-f58c-4a42-9193-3bf33ed54d1e/23733043673-500.jpg",
@@ -6647,12 +6647,12 @@
   "cd-1329-sepultura-roorback": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:26:33.064Z"
+    "resolvedAt": "2026-03-27T10:50:39.015Z"
   },
   "cd-1330-sergei-prokofiev-benjamin-britten-sean-c": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:26:34.911Z"
+    "resolvedAt": "2026-03-27T10:50:41.710Z"
   },
   "cd-1331-emma-shapplin-carmine-meo": {
     "url": "http://coverartarchive.org/release/6678b1f4-1746-3e81-817f-2ff793da2267/9968263997-500.jpg",
@@ -6675,54 +6675,54 @@
     "resolvedAt": "2026-03-26T18:26:52.954Z"
   },
   "cd-1335-shirley-horn-the-main-ingredient": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:26:55.402Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/36/18/c7/3618c7fb-b4ea-d5f9-9abe-385df44ed97c/00602557667929.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:42.952Z"
   },
   "cd-1336-shlomo-mintz-giuseppe-sinopoli-beethoven": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:26:57.246Z"
+    "resolvedAt": "2026-03-27T10:50:45.725Z"
   },
   "cd-1337-jussara-silveira-cancoes-de-caymmi": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:26:59.288Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/18/cf/2a/18cf2a94-65a9-9e2c-5dca-93f86c06782c/889845589280.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:47.034Z"
   },
   "cd-1338-jussara-silveira-pedras-que-rolam-objeto": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:27:01.439Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/6a/16/c2/6a16c2a5-3504-5419-31aa-c7d739685a12/889845153023.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:48.336Z"
   },
   "cd-1339-horace-silver-horace-silver": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:27:03.654Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/b0/65/3e/b0653efc-f6a4-1b5a-f0ad-6e4cec935ca9/00094633777552.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:49.687Z"
   },
   "cd-1340-horace-silver-the-hardbop-grandpop": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:27:05.855Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/6d/ec/d3/6decd3f3-15ef-a3f2-5d59-ff2db16e72ac/00011105019224.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:50:51.023Z"
   },
   "cd-1341-silvio-caldas-o-caboclinho-querido": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:27:11.554Z"
+    "resolvedAt": "2026-03-27T10:50:56.854Z"
   },
   "cd-1342-simone-25-de-dezembro": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:27:13.906Z"
+    "resolvedAt": "2026-03-27T10:51:00.138Z"
   },
   "cd-1343-jose-simonian-ouvi-do-brasileiro": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:27:15.761Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/db/92/7d/db927d70-444b-c6b9-49e3-3f6a6f5f7f9f/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:01.403Z"
   },
   "cd-1344-simply-red-men-and-women": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:27:17.904Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/e9/38/8f/mzi.hlqmwdnm.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:02.634Z"
   },
   "cd-1345-frank-sinatra-frank-sinatra": {
     "url": "http://coverartarchive.org/release/b86bfab9-f31a-4d43-9f3a-fc92a11c41ed/1475309460-500.jpg",
@@ -6735,9 +6735,9 @@
     "resolvedAt": "2026-03-26T18:27:27.160Z"
   },
   "cd-1347-sivuca-o-melhor-do-forro": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:27:29.034Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/eb/d9/cc/ebd9cc45-2e07-dcb3-0110-42b46abba275/7898324755835.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:03.873Z"
   },
   "cd-1348-skank-siderado": {
     "url": "https://coverartarchive.org/release/47365fe9-8d65-4709-bb94-747b22aa0400/44064508815-500.jpg",
@@ -6747,7 +6747,7 @@
   "cd-1349-skank-vamos-fugir": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:27:38.018Z"
+    "resolvedAt": "2026-03-27T10:51:06.616Z"
   },
   "cd-1350-phoebe-snow-the-best-of-phoebe-snow": {
     "url": "http://coverartarchive.org/release/ddbaa228-1f3a-48cc-a6fe-ad821d3ae7a5/10495123655-500.jpg",
@@ -6772,7 +6772,7 @@
   "cd-1354-sonny-rollins-alternatives": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:27:57.108Z"
+    "resolvedAt": "2026-03-27T10:51:09.600Z"
   },
   "cd-1355-sonny-rollins-global-warming": {
     "url": "http://coverartarchive.org/release/39786b33-decc-4ab7-9e9d-e0e3479264fd/29987752626-500.jpg",
@@ -6790,14 +6790,14 @@
     "resolvedAt": "2026-03-26T18:28:06.866Z"
   },
   "cd-1358-sonny-rollins-sonny-rollins-plus-4": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:09.104Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/40/42/86/4042866d-4d50-7a7b-ec15-9cdcc04d5b6a/25CRGIM48465.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:10.986Z"
   },
   "cd-1359-sonny-rollins-sonny-rollins-vol-1": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:11.044Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/c5/a3/e8/c5a3e8e2-a90d-1790-34fe-cb7f1449accf/13UAAIM69196.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:12.420Z"
   },
   "cd-1360-sonny-rollins-tenor-madness": {
     "url": "https://coverartarchive.org/release/f2ee4f73-84e6-468d-b438-7076977b518d/38471108780-500.jpg",
@@ -6805,9 +6805,9 @@
     "resolvedAt": "2026-03-26T18:28:15.598Z"
   },
   "cd-1361-sonny-rollins-the-bridge": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:17.913Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/ad/2e/30/ad2e30bd-e999-5945-ec5e-aa2f26986283/828765247221.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:13.791Z"
   },
   "cd-1362-sonny-rollins-this-is-what-i-do": {
     "url": "http://coverartarchive.org/release/621da595-85d9-47f1-a650-59f4b31620f3/15956118426-500.jpg",
@@ -6815,24 +6815,24 @@
     "resolvedAt": "2026-03-26T18:28:22.130Z"
   },
   "cd-1363-sound-stage-genuinamente-brasileiro-vol-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:24.154Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/0f/5b/ab/mzi.ekxedulf.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:15.186Z"
   },
   "cd-1364-soundscape-big-band-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:25.993Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/30/42/c3/3042c359-1c3a-d0ac-00e0-4d1141967a73/633367883223.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:16.931Z"
   },
   "cd-1365-luciana-souza-an-answer-to-your-silence": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:28.220Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/87/02/1a/mzi.sostraqd.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:18.202Z"
   },
   "cd-1366-spice-girls-spice": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:30.308Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/88/85/6e/88856e99-7323-7737-3634-435da9fcefa0/13UABIM59225.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:19.619Z"
   },
   "cd-1367-spice-girls-spiceworld": {
     "url": "http://coverartarchive.org/release/8ebbb6c9-0ec0-43d8-9fcd-fc3824879aaf/10723204031-500.jpg",
@@ -6845,9 +6845,9 @@
     "resolvedAt": "2026-03-26T18:28:39.269Z"
   },
   "cd-1369-staatskapelle-berlin-symphony-no-9": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:28:41.502Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/88/38/0a/88380a04-7beb-bd2e-667a-6fe81796a81a/18UMGIM48582.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:21.045Z"
   },
   "cd-1370-stan-getz-verve-jazz-masters-8": {
     "url": "http://coverartarchive.org/release/f1a704e5-8e9e-45c2-8e28-521092dae3ad/19118062906-500.jpg",
@@ -6890,9 +6890,9 @@
     "resolvedAt": "2026-03-26T18:29:13.402Z"
   },
   "cd-1378-steely-dan-everything-must-go": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:29:15.507Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/03/79/72/dj.jxtrwpqs.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:22.389Z"
   },
   "cd-1379-steely-dan-gaucho": {
     "url": "https://coverartarchive.org/release/a2d41382-bfea-4178-80e2-4b8110f7aba5/8706939982-500.jpg",
@@ -6935,19 +6935,19 @@
     "resolvedAt": "2026-03-26T18:29:50.118Z"
   },
   "cd-1387-stephen-scott-the-beautiful-thing": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:29:52.505Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/3f/05/75/3f05753d-5a41-b978-091a-8655f7d1788a/00731453318625.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:24.106Z"
   },
   "cd-1388-stephen-scott-vision-quest": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:29:54.704Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/a0/8f/96/a08f96b2-e6ac-3423-e346-6665094ddb61/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:25.387Z"
   },
   "cd-1389-steve-coleman-flashback-on-m-base": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:29:56.900Z"
+    "resolvedAt": "2026-03-27T10:51:29.984Z"
   },
   "cd-1390-steve-coleman-genesis": {
     "url": "http://coverartarchive.org/release/488068af-68d8-4dce-a4a9-49682b39c75b/26990942082-500.jpg",
@@ -6960,9 +6960,9 @@
     "resolvedAt": "2026-03-26T18:30:05.980Z"
   },
   "cd-1392-steve-swallow-swallow": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:30:08.117Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/9e/ed/b5/9eedb527-ea7a-cb7a-10b7-5fb076f6eb13/00731451196027.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:31.441Z"
   },
   "cd-1393-steve-turre-in-the-spur-of-the-moment": {
     "url": "http://coverartarchive.org/release/e1830173-8f5a-4959-99c6-f0c597c38a03/27178443037-500.jpg",
@@ -6990,9 +6990,9 @@
     "resolvedAt": "2026-03-26T18:30:29.332Z"
   },
   "cd-1398-rod-stewart-fly-me-to-the-moon-the-great": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:30:31.564Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/60/54/cb/mzi.yxswvldv.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:32.692Z"
   },
   "cd-1399-rod-stewart-it-had-to-be-you-the-great-a": {
     "url": "https://coverartarchive.org/release/f9474884-a9b8-4578-9eeb-48ebe8c3f0d4/9755291286-500.jpg",
@@ -7000,9 +7000,9 @@
     "resolvedAt": "2026-03-26T18:30:35.886Z"
   },
   "cd-1400-sting-all-this-time": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:30:38.355Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/6c/9d/4b/6c9d4b85-c0a7-16b9-75a0-28ad254e8ee0/06UMGIM19844.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:34.130Z"
   },
   "cd-1401-sting-brand-new-day": {
     "url": "http://coverartarchive.org/release/e8163bcf-96ac-4505-a1da-702699a277aa/26067826227-500.jpg",
@@ -7025,9 +7025,9 @@
     "resolvedAt": "2026-03-26T18:30:55.547Z"
   },
   "cd-1405-sujeito-a-guincho-sujeito-a-guincho": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:30:57.383Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/8d/81/12/8d811297-abc7-92be-9705-2e480c50f230/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:35.385Z"
   },
   "cd-1406-supla-o-charada-brasileiro": {
     "url": "http://coverartarchive.org/release/d08d0718-dc7c-45d1-b6d4-29268cc0751d/10027678871-500.jpg",
@@ -7035,24 +7035,24 @@
     "resolvedAt": "2026-03-26T18:31:01.794Z"
   },
   "cd-1407-david-sylvian-robert-fripp-the-first-day": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:04.016Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/ac/b5/a7/acb5a72d-6498-717c-f3ca-5486e189bc57/633367883926.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:36.636Z"
   },
   "cd-1408-luciano-taioli-disco-d-oro": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:06.083Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music62/v4/c9/6f/db/c96fdb30-ae3c-8067-6e68-73c8d79e8f63/8028068100601.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:37.870Z"
   },
   "cd-1409-luciano-tajoli-a-napoli-con-affeto": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:31:08.030Z"
+    "resolvedAt": "2026-03-27T10:51:40.598Z"
   },
   "cd-1410-luciano-tajoli-il-meglio-dei-30-anni-vol": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:10.095Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/33/ee/ec/mzi.hzihaeix.tif/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:41.923Z"
   },
   "cd-1411-take-6-join-the-band": {
     "url": "http://coverartarchive.org/release/abea73de-6053-4c23-905d-89f99f6c0e3d/28709916223-500.jpg",
@@ -7060,34 +7060,34 @@
     "resolvedAt": "2026-03-26T18:31:14.778Z"
   },
   "cd-1412-take-6-so-much-to-say": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:16.870Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music71/v4/0d/09/59/0d09593d-b935-cc43-226a-587c4430464e/075992589260.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:43.221Z"
   },
   "cd-1413-tal-farlow-and-others-all-strings-attach": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:31:18.711Z"
+    "resolvedAt": "2026-03-27T10:51:46.923Z"
   },
   "cd-1414-taska-taska": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:20.713Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music5/v4/46/55/31/4655318d-e152-1a64-371a-512b0a2a8d9d/7894770002394.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:48.171Z"
   },
   "cd-1415-teco-cardoso-meu-brasil": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:31:22.653Z"
+    "resolvedAt": "2026-03-27T10:51:50.922Z"
   },
   "cd-1416-teco-cardoso-lea-freire-quinteto": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:24.598Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/48/4f/e8/mzi.jcybumlt.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:52.231Z"
   },
   "cd-1417-cleston-teixeira-o-mundo-partiu-se-em-do": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:31:26.485Z"
+    "resolvedAt": "2026-03-27T10:51:54.960Z"
   },
   "cd-1418-renato-teixeira-acervo-especial": {
     "url": "http://coverartarchive.org/release/d56e9a80-3a62-4f52-ab8f-bf473f777430/10115926959-500.jpg",
@@ -7125,24 +7125,24 @@
     "resolvedAt": "2026-03-26T18:31:56.189Z"
   },
   "cd-1425-thad-jones-mel-lewis-orchestra-a-touch-o": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:31:58.492Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/a8/53/99/a85399b7-f30b-303e-511f-a36e6e31254a/00724353822651.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:51:57.170Z"
   },
   "cd-1426-the-art-ensemble-of-chicago-coming-home-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:32:02.909Z"
+    "resolvedAt": "2026-03-27T10:51:59.876Z"
   },
   "cd-1427-the-art-ensemble-of-chicago-third-decade": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:07.926Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/19/f3/93/19f39391-6e5d-b4b6-e1a7-5e953b4dd824/00602577323362.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:01.135Z"
   },
   "cd-1428-the-art-of-noise-below-the-waste": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:10.031Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music7/v4/81/10/41/8110418d-e95f-c279-fa56-8d24961d6027/825646110445.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:02.446Z"
   },
   "cd-1429-the-benny-green-trio-that-s-right": {
     "url": "http://coverartarchive.org/release/85ac1a36-d8cc-48ce-89fc-c95a45330f3a/31397263400-500.jpg",
@@ -7150,14 +7150,14 @@
     "resolvedAt": "2026-03-26T18:32:16.315Z"
   },
   "cd-1430-the-branford-marsalis-quartet-crazy-peop": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:22.364Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/7f/26/fb/mzi.jmdnwzpd.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:03.775Z"
   },
   "cd-1431-the-branford-marsalis-quartet-mo-better-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:24.684Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/77/57/85/mzi.fkqdlgcp.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:05.154Z"
   },
   "cd-1432-the-carla-bley-band-i-hate-to-sing": {
     "url": "http://coverartarchive.org/release/4081d3fb-2527-4219-a1d7-cd74148be1a6/36722924601-500.jpg",
@@ -7165,24 +7165,24 @@
     "resolvedAt": "2026-03-26T18:32:29.420Z"
   },
   "cd-1433-the-fifth-dimension-greatest-hits-on-ear": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:31.474Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/9b/a3/ef/9ba3efe7-c02b-0579-7fc6-d7050fbe225a/mzi.fakwjhti.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:06.404Z"
   },
   "cd-1434-the-gil-evans-orchestra-blues-in-orbit": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:32:33.998Z"
+    "resolvedAt": "2026-03-27T10:52:10.607Z"
   },
   "cd-1435-the-gil-evans-orchestra-live-at-umbria-j": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:36.086Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/49/e0/38/49e03829-5cbf-3b9c-0f69-1d3148eb55d5/8055271678337_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:11.932Z"
   },
   "cd-1436-the-grateful-dead-the-very-best-of-grate": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:32:47.822Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/e9/b6/e2/e9b6e214-1f54-8386-913b-e245fa960ff6/603497920761.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:13.357Z"
   },
   "cd-1437-the-harper-brothers-you-can-hide-inside-": {
     "url": "https://coverartarchive.org/release/d4e74b5b-0763-4420-94d9-cc3c3bc70876/44047619741-500.jpg",
@@ -7205,9 +7205,9 @@
     "resolvedAt": "2026-03-26T18:33:17.349Z"
   },
   "cd-1441-the-manhattan-transfer-the-manhattan-tra": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:33:26.971Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/19/d1/e9/19d1e968-ef64-0a6c-bdac-d92a2018cef5/18CRGIM06073.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:14.609Z"
   },
   "cd-1442-the-manhattan-transfer-the-very-best-of-": {
     "url": "http://coverartarchive.org/release/4bc768b9-c932-437d-b5d6-077ca3114b18/28266492499-500.jpg",
@@ -7215,9 +7215,9 @@
     "resolvedAt": "2026-03-26T18:33:32.104Z"
   },
   "cd-1443-the-modern-jazz-quartet-at-music-inn": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:33:34.412Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/18/97/a2/mzi.cnodabde.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:15.948Z"
   },
   "cd-1444-the-modern-jazz-quartet-blues-on-bach": {
     "url": "http://coverartarchive.org/release/c6f5c3db-7ab1-4e02-8f76-7cdf73c8c488/11805364049-500.jpg",
@@ -7225,9 +7225,9 @@
     "resolvedAt": "2026-03-26T18:33:47.997Z"
   },
   "cd-1445-the-modern-jazz-quartet-concorde": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:33:50.625Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/00/69/c6/0069c6ec-617a-8251-e2a2-9ac80455d0b2/00888072352193.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:17.318Z"
   },
   "cd-1446-the-modern-jazz-quartet-django": {
     "url": "http://coverartarchive.org/release/557abe33-bf9d-49e5-bded-93a2aa8bc8b9/11288021032-500.jpg",
@@ -7240,14 +7240,14 @@
     "resolvedAt": "2026-03-26T18:34:00.876Z"
   },
   "cd-1448-the-modern-jazz-quartet-mjq-friends": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:02.854Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/y2005/m08/d18/h19/mzi.vatryejt.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:18.588Z"
   },
   "cd-1449-the-modern-jazz-quartet-modern-jazz-quar": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:11.411Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/e9/a6/6b/e9a66bc9-b3cb-bb45-dcc8-8c9b5ad50a41/3149028144499_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:20.003Z"
   },
   "cd-1450-the-nat-king-cole-trio-the-complete-afte": {
     "url": "http://coverartarchive.org/release/9491bbef-53a1-4684-8ff9-11376b31f925/25646066084-500.jpg",
@@ -7255,9 +7255,9 @@
     "resolvedAt": "2026-03-26T18:34:17.041Z"
   },
   "cd-1451-the-nat-king-cole-trio-too-marvellous-fo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:19.334Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/41/3e/eb/413eebab-c72f-5970-f207-d51bf152e139/15UMGIM08561.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:21.306Z"
   },
   "cd-1452-the-neville-brothers-valence-street": {
     "url": "http://coverartarchive.org/release/b3ea04ae-c833-47cb-814f-67418542c786/32814162079-500.jpg",
@@ -7265,84 +7265,84 @@
     "resolvedAt": "2026-03-26T18:34:24.758Z"
   },
   "cd-1453-the-ray-brown-trio-summertime": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:26.984Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/ae/21/68/ae21683c-a098-f927-4c17-ffc9580148ef/23CRGIM36253.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:22.675Z"
   },
   "cd-1454-the-rob-madna-trio-the-dutch-jazz-orches": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:34:28.885Z"
+    "resolvedAt": "2026-03-27T10:52:26.039Z"
   },
   "cd-1455-the-roy-haynes-trio-the-roy-haynes-trio": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:30.825Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/32/1f/5a/321f5a6d-4ea5-708a-76a4-47e0e7cf4372/00731454353427.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:27.293Z"
   },
   "cd-1456-the-royal-philharmonic-orchestra-cesar-f": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:32.671Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/4c/49/f0/4c49f0c9-94c9-a9ac-8cf1-95a2200abb7e/754523560458.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:28.534Z"
   },
   "cd-1457-the-royal-philharmonic-orchestra-claude-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:34.559Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/5f/f2/dc/mzi.cjpwuohz.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:29.793Z"
   },
   "cd-1458-the-royal-philharmonic-orchestra-franz-s": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:36.434Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/00/2b/37/002b3762-f560-3377-1f84-41abe28cd36a/074646184226.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:31.114Z"
   },
   "cd-1459-the-royal-philharmonic-orchestra-franz-s": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:38.298Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/00/2b/37/002b3762-f560-3377-1f84-41abe28cd36a/074646184226.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:32.155Z"
   },
   "cd-1460-the-royal-philharmonic-orchestra-frederi": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:40.185Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/29/b9/8f/29b98f15-87bf-ae87-f0fd-eb2bb22677ec/00028947780106.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:33.443Z"
   },
   "cd-1461-the-royal-philharmonic-orchestra-giacomo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:42.036Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/2c/ae/3a/2cae3a0a-fd70-c4e7-ba64-73b786e47667/00028947865421.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:35.116Z"
   },
   "cd-1462-the-royal-philharmonic-orchestra-gustav-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:45.543Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/3a/fe/d0/3afed08a-0fa6-56d6-0684-2c8729cca8d8/00028943778923.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:36.376Z"
   },
   "cd-1463-the-royal-philharmonic-orchestra-johann-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:47.399Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/d8/da/87/mzi.dmkmisbk.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:37.729Z"
   },
   "cd-1464-the-royal-philharmonic-orchestra-joseph-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:49.327Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/70/c4/c3/70c4c364-370d-b8ea-8555-fb0ab5a18172/4260716431918_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:39.066Z"
   },
   "cd-1465-the-royal-philharmonic-orchestra-leo-del": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:51.162Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/30/97/14/30971457-4314-38c5-1fc1-63220dd6d0d6/886445411850.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:40.346Z"
   },
   "cd-1466-the-royal-philharmonic-orchestra-pyotr-i": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:53.074Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/b2/f0/e0/b2f0e00e-2234-ba12-f56c-fb9bab3becf9/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:41.601Z"
   },
   "cd-1467-the-royal-philharmonic-orchestra-wolfgan": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:55.035Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/e1/25/d1/e125d139-067d-b01b-052d-935c8da640fc/26UMGIM04499.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:43.042Z"
   },
   "cd-1468-the-zawinul-sindicate-lost-tribes": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:34:56.954Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features/55/f3/3b/dj.synuayki.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:44.297Z"
   },
   "cd-1469-thelonious-monk-complete-blue-note-recor": {
     "url": "http://coverartarchive.org/release/adbe683d-eb90-4a6c-97dc-5024028d6ce6/10249416785-500.jpg",
@@ -7350,9 +7350,9 @@
     "resolvedAt": "2026-03-26T18:35:02.305Z"
   },
   "cd-1470-thelonious-monk-genius-of-modern-music-v": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:04.602Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/49/00/2d/49002d37-68b5-b6ea-243d-e2e152375015/00724353213855.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:45.807Z"
   },
   "cd-1471-thelonious-monk-genius-of-modern-music-v": {
     "url": "http://coverartarchive.org/release/b1338e32-e5c8-47e9-9948-170426313494/6442481446-500.jpg",
@@ -7365,9 +7365,9 @@
     "resolvedAt": "2026-03-26T18:35:13.686Z"
   },
   "cd-1473-thelonious-monk-live-at-the-it-club": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:15.808Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/67/e3/08/67e30894-2fb9-0bdc-ae63-b5c94c999fc3/074646528822.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:47.129Z"
   },
   "cd-1474-thelonious-monk-misterioso": {
     "url": "http://coverartarchive.org/release/94ff81cd-605b-436f-94da-ccfe478ccc6d/36644646043-500.jpg",
@@ -7380,34 +7380,34 @@
     "resolvedAt": "2026-03-26T18:35:24.901Z"
   },
   "cd-1476-thelonious-monk-monk-s-blues": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:26.964Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f2/81/2df2813f-bcb8-5a7f-0959-e201a580ca08/074645358123.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:48.427Z"
   },
   "cd-1477-thelonious-monk-straight-no-chaser": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:29.113Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features124/v4/69/f0/8c/69f08c37-6f6a-970f-f53f-ef3f99642fca/dj.wvzxyszi.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:49.689Z"
   },
   "cd-1478-thelonious-monk-the-complete-black-lion-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:31.705Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Features124/v4/69/f0/8c/69f08c37-6f6a-970f-f53f-ef3f99642fca/dj.wvzxyszi.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:50.946Z"
   },
   "cd-1479-thelonious-monk-the-complete-black-lion-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:35:33.592Z"
+    "resolvedAt": "2026-03-27T10:52:54.263Z"
   },
   "cd-1480-thelonious-monk-the-complete-black-lion-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:35:35.425Z"
+    "resolvedAt": "2026-03-27T10:52:57.266Z"
   },
   "cd-1481-thelonious-monk-the-way-i-feel-now-tribu": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:37.310Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/85/7a/fd/857afd11-d88b-898b-21bf-68cd126638b3/00888072390232.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:58.548Z"
   },
   "cd-1482-thelonious-monk-thelonious-monk-and-sonn": {
     "url": "https://coverartarchive.org/release/810020ec-795f-4f91-832e-0b5c9c6b15d2/39934219392-500.jpg",
@@ -7415,9 +7415,9 @@
     "resolvedAt": "2026-03-26T18:35:42.089Z"
   },
   "cd-1483-thelonious-monk-thelonious-monk-with-joh": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:44.399Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/85/7a/fd/857afd11-d88b-898b-21bf-68cd126638b3/00888072390232.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:52:59.876Z"
   },
   "cd-1484-thelonious-monk-quartet-monk-s-dream": {
     "url": "http://coverartarchive.org/release/391462cb-1d78-40a8-9cd1-e23ee1a00b9f/13148845318-500.jpg",
@@ -7425,9 +7425,9 @@
     "resolvedAt": "2026-03-26T18:35:50.546Z"
   },
   "cd-1485-the-three-degrees-the-best-of-the-three-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:35:52.581Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/d9/ec/1b/d9ec1b3a-1716-da66-3a3c-76a98ac9458b/mzi.zkyzqfdk.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:01.278Z"
   },
   "cd-1486-wagner-tiso-memorial": {
     "url": "http://coverartarchive.org/release/af5f910f-b32a-4a16-bd9a-a0f41b27cb04/22535546502-500.jpg",
@@ -7440,9 +7440,9 @@
     "resolvedAt": "2026-03-26T18:36:01.035Z"
   },
   "cd-1488-titas-titas-acustico": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:02.861Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music18/v4/8b/23/f1/8b23f112-5da0-95c2-e718-291fa1089135/825646319619.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:02.704Z"
   },
   "cd-1489-titas-volume-dois": {
     "url": "http://coverartarchive.org/release/b6d63db4-7d51-40d6-8ad1-3e209097175e/35362701894-500.jpg",
@@ -7455,9 +7455,9 @@
     "resolvedAt": "2026-03-26T18:36:11.347Z"
   },
   "cd-1491-tommy-dorsey-frank-sinatra-toghether": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:13.570Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/dc/70/96/dc7096e5-be0a-e0bf-d859-d7eb2ce0f9bd/886443610545.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:04.010Z"
   },
   "cd-1492-tommy-flanagan-beyond-the-blue-bird": {
     "url": "http://coverartarchive.org/release/ef066027-15a2-4ac8-adbf-37ae5e57e9b8/36757731496-500.jpg",
@@ -7465,29 +7465,29 @@
     "resolvedAt": "2026-03-26T18:36:19.125Z"
   },
   "cd-1493-tommy-flanagan-trio-lady-be-good-for-ell": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:21.177Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/92/d0/1c/92d01c6d-5b99-f180-b45e-6f86156ba779/00025218618229.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:05.357Z"
   },
   "cd-1494-toni-braxton-secrets": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:23.350Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/fd/61/1f/fd611f8f-1edc-8c6a-ce32-2882441f5f82/886443468986.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:06.632Z"
   },
   "cd-1495-toni-garrido-todo-meu-canto": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:36:25.189Z"
+    "resolvedAt": "2026-03-27T10:53:09.523Z"
   },
   "cd-1496-toninho-horta-once-i-loved": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:36:27.352Z"
+    "resolvedAt": "2026-03-27T10:53:13.423Z"
   },
   "cd-1497-toniquinho-batuqueiro-toniquinho-batuque": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:29.238Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/e4/48/fc/mzi.shlsqgco.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:14.771Z"
   },
   "cd-1498-tony-bennett-here-s-to-the-ladies": {
     "url": "http://coverartarchive.org/release/9f0bddbc-963b-4bad-8c10-871e9f584562/4435405463-500.jpg",
@@ -7505,14 +7505,14 @@
     "resolvedAt": "2026-03-26T18:36:44.205Z"
   },
   "cd-1501-toots-thielemans-elis-regina-aquarela-do": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:46.130Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/c4/2e/c6/c42ec603-05ed-66e1-e452-715662d831c7/00042283039124.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:16.153Z"
   },
   "cd-1502-toquinho-30-anos-de-musica": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:47.975Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/5d/fd/e4/5dfde4d5-0e90-bd76-659a-19b410dffc6b/Cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:17.418Z"
   },
   "cd-1503-toquinho-italiano": {
     "url": "http://coverartarchive.org/release/eb17929b-cb1c-4de7-9cd9-6d0176ffabee/16965630776-500.jpg",
@@ -7520,49 +7520,49 @@
     "resolvedAt": "2026-03-26T18:36:52.466Z"
   },
   "cd-1504-toquinho-o-melhor-de-toquinho": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:54.538Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/27/59/36/275936dc-e2d1-60ac-41ca-ab49576ad85e/7891430077471.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:18.654Z"
   },
   "cd-1505-marcelo-torres-jazz-friends": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:56.415Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music2/v4/54/40/58/54405830-6144-8446-1478-b928c77e4242/dj.ancdljxk.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:20.044Z"
   },
   "cd-1506-toshinori-kondo-ima-kamikaze-blow": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:36:58.242Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/d4/42/09/d442094b-8bb0-267a-ad47-5b0c38de8221/193428928350.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:21.280Z"
   },
   "cd-1507-trash-pour-4-recycle-vol-1": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:00.127Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/d0/df/e2/d0dfe205-cfe2-38db-69ef-9fe35658be2e/192562693858.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:22.546Z"
   },
   "cd-1508-trash-pour-4-superduper": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:01.967Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/c0/74/e5/c074e54d-e6b3-b2f0-a892-84504591744b/192562703007.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:24.001Z"
   },
   "cd-1509-tres-pontos-tres-pontos": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:03.800Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/2c/02/8d/2c028d99-6939-5e30-29ad-e6c4c3c48569/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:25.326Z"
   },
   "cd-1510-trio-esperanca-do-brazil-a-capela": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:05.641Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/f1/af/db/f1afdb0f-045d-bbe6-f1a3-bc1027885ece/00731451869228.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:26.635Z"
   },
   "cd-1511-trio-preto-1-trio-preto-1": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:07.473Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/66/85/49/66854924-c844-60d1-44e8-a6a708ba05d0/00028947998587.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:27.897Z"
   },
   "cd-1512-trovadores-urbanos-trovadores-urbanos-se": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:09.325Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/d6/5b/30/d65b3045-a2b3-ead2-e668-531bd494ab47/7891397002738.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:29.336Z"
   },
   "cd-1513-ts-monk-crosstalk": {
     "url": "http://coverartarchive.org/release/aa5eb912-a82e-4ce9-bdd1-f8af7cc50ae0/30690789799-500.jpg",
@@ -7607,7 +7607,7 @@
   "cd-1521-tutty-moreno-rodolfo-stroeter-andre-mehm": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:37:47.916Z"
+    "resolvedAt": "2026-03-27T10:53:32.610Z"
   },
   "cd-1522-u2-how-to-dismantle-an-atomic-bomb": {
     "url": "http://coverartarchive.org/release/1bf67755-19e7-467f-8e83-0659084066e3/11975166281-500.jpg",
@@ -7620,9 +7620,9 @@
     "resolvedAt": "2026-03-26T18:37:55.675Z"
   },
   "cd-1524-universo-gafieira-moderno-com-tradiciona": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:37:57.514Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/47/a0/22/47a022c9-2393-adad-e3fa-b727743e1bda/7899478205825.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:33.867Z"
   },
   "cd-1525-us3-hand-on-the-torch": {
     "url": "http://coverartarchive.org/release/2bf11d4c-8505-4589-856d-30ee505669dd/12029998374-500.jpg",
@@ -7632,7 +7632,7 @@
   "cd-1526-van-morrison-georgie-fame-how-long-has-t": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:38:05.752Z"
+    "resolvedAt": "2026-03-27T10:53:38.285Z"
   },
   "cd-1527-vanessa-bumagny-de-papel": {
     "url": "http://coverartarchive.org/release/b6598e29-40fc-4989-bdc2-ced5209a5619/21527809791-500.jpg",
@@ -7667,17 +7667,17 @@
   "cd-1533-various-de-uma-chance-a-paz-john-lennon-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:38:31.573Z"
+    "resolvedAt": "2026-03-27T10:53:41.404Z"
   },
   "cd-1534-various-divas-do-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:38:33.748Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/d9/d7/7a/d9d77a49-4de2-0223-c1c8-c61958f4783f/5054197184628.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:42.709Z"
   },
   "cd-1535-various-el-jazz-la-pintura-moderna-museo": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:38:35.617Z"
+    "resolvedAt": "2026-03-27T10:53:45.472Z"
   },
   "cd-1536-various-get-shorty-original-mgm-motion-p": {
     "url": "https://coverartarchive.org/release/3fcea75b-4779-47cd-9d5f-0014191ab162/40942778216-500.jpg",
@@ -7685,9 +7685,9 @@
     "resolvedAt": "2026-03-26T18:38:39.920Z"
   },
   "cd-1537-various-in-from-the-storm-the-music-of-j": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:38:41.940Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/b0/90/17/b09017b9-1924-cd06-52b9-fed7e8dc8e96/886444746908.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:46.787Z"
   },
   "cd-1538-various-kansas-city-a-robert-altman-film": {
     "url": "http://coverartarchive.org/release/f8077ac4-e17c-4344-90f6-f85fdba0409c/31328249416-500.jpg",
@@ -7695,9 +7695,9 @@
     "resolvedAt": "2026-03-26T18:38:48.315Z"
   },
   "cd-1539-various-lamartine-babo": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:38:50.356Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/f0/b2/53/f0b253c0-56f8-6b10-c709-259c7a5be2e4/8721253812692.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:48.044Z"
   },
   "cd-1540-various-lisbela-e-o-prisioneiro": {
     "url": "http://coverartarchive.org/release/78a0097b-d306-4c0f-a41e-0e78a5b94b63/3780578642-500.jpg",
@@ -7710,19 +7710,19 @@
     "resolvedAt": "2026-03-26T18:39:00.524Z"
   },
   "cd-1542-various-mainstream": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:02.796Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/81/2f/27/812f27f8-4c88-7b16-8a54-5113fa169781/dj.jvcruggi.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:49.297Z"
   },
   "cd-1543-various-mike-mainieri-presents-come-toge": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:39:04.676Z"
+    "resolvedAt": "2026-03-27T10:53:52.176Z"
   },
   "cd-1544-various-motown-legends-duets": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:06.753Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/a7/00/05/a70005c0-c3cd-d79e-1947-576b7b1c0738/06UMGIM09541.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:53:53.446Z"
   },
   "cd-1545-various-motown-legends-volume-1": {
     "url": "https://coverartarchive.org/release/986a770d-3e5e-43f5-aca3-7be654072849/43287515859-500.jpg",
@@ -7732,22 +7732,22 @@
   "cd-1546-various-nelson-motta-noites-tropicais": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:39:13.310Z"
+    "resolvedAt": "2026-03-27T10:53:56.160Z"
   },
   "cd-1547-various-o-baile-do-simonal": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:39:15.143Z"
+    "resolvedAt": "2026-03-27T10:53:58.971Z"
   },
   "cd-1548-various-one-night-with-blue-note-preserv": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:17.302Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/6b/fb/d0/6bfbd09d-023b-8940-aca5-29cfd46e1a69/22UMGIM42956.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:00.357Z"
   },
   "cd-1549-various-organ-spectacular": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:19.392Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/fa/32/a9/fa32a9f3-0e36-83ce-5f07-9e41421c9f19/196292168440.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:01.696Z"
   },
   "cd-1550-various-os-sambas-do-milenio": {
     "url": "https://coverartarchive.org/release/b63262a5-6ca4-48ab-a526-d3ed9c455247/42055979500-500.jpg",
@@ -7755,14 +7755,14 @@
     "resolvedAt": "2026-03-26T18:39:23.958Z"
   },
   "cd-1551-various-red-hot-blue": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:28.416Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/22/3e/ed/223eedeb-3ad1-2bd8-c863-ab6fb39d658a/093624920137.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:03.164Z"
   },
   "cd-1552-various-red-hot-rhapsody-the-gershwin-gr": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:30.686Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/bd/aa/51/bdaa5172-5905-bea4-5195-b869874791ac/00731455778823.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:04.470Z"
   },
   "cd-1553-various-salsa-around-the-world": {
     "url": "http://coverartarchive.org/release/682e1611-c821-4e09-a5c1-7d3d2e688466/22480793392-500.jpg",
@@ -7777,12 +7777,12 @@
   "cd-1555-various-talkin-verve-with-a-twist": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:39:42.101Z"
+    "resolvedAt": "2026-03-27T10:54:08.334Z"
   },
   "cd-1556-various-the-great-ladies-sing-gershwin": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:44.449Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/a9/c5/80/a9c5805d-f570-9c5d-aab9-0db1f599c149/06UMGIM08156.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:09.653Z"
   },
   "cd-1557-various-the-new-groove-the-blue-note-rem": {
     "url": "http://coverartarchive.org/release/17eaa79a-de73-46e2-adc1-ffb6037f5b9a/7930076517-500.jpg",
@@ -7790,9 +7790,9 @@
     "resolvedAt": "2026-03-26T18:39:49.999Z"
   },
   "cd-1558-various-thriller-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:39:52.602Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/33/6e/8d/336e8d4d-8621-dc19-cd3c-48a5543bfba4/5026328202709.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:10.915Z"
   },
   "cd-1559-various-west-coast": {
     "url": "http://coverartarchive.org/release/89157de6-9bf9-4e93-b63c-3ab1b7ecc46a/20240971356-500.jpg",
@@ -7807,27 +7807,27 @@
   "cd-1561-various-artists-26th-fujistu-concord-jaz": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:04.990Z"
+    "resolvedAt": "2026-03-27T10:54:13.664Z"
   },
   "cd-1562-various-artists-arca-de-noe-2": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:40:07.408Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/02/5d/85/025d850b-9796-7191-289d-625b59b30572/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:14.952Z"
   },
   "cd-1563-various-artists-as-marchinhas-de-carnava": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:40:09.680Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/ba/9a/e9/ba9ae95f-8b4b-002a-a315-8564cc8b361b/198003667921.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:16.227Z"
   },
   "cd-1564-various-artists-baiao-de-viramundo-tribu": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:40:11.568Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/f8/33/95/mzi.wviujdpc.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:17.687Z"
   },
   "cd-1565-various-artists-bossa-nova-lounge-dreame": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:40:14.405Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music117/v4/f6/fc/b4/f6fcb493-2b56-5af1-d20a-e9dbd5afeb3d/SC396_1440px.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:18.971Z"
   },
   "cd-1566-various-artists-burnt-by-rock-n-roll": {
     "url": "http://coverartarchive.org/release/6f2d28cf-0403-4bc0-9fb0-040104d3231e/4669109328-500.jpg",
@@ -7837,7 +7837,7 @@
   "cd-1567-various-artists-caipira-raizes-e-frutos": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:20.798Z"
+    "resolvedAt": "2026-03-27T10:54:21.881Z"
   },
   "cd-1568-various-artists-capitol-sings-george-ger": {
     "url": "https://coverartarchive.org/release/a989eb83-2dd0-4aa7-8940-ca97033139fd/36746916688-500.jpg",
@@ -7847,32 +7847,32 @@
   "cd-1569-various-artists-caras-compositores-vol-5": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:27.666Z"
+    "resolvedAt": "2026-03-27T10:54:24.776Z"
   },
   "cd-1570-various-artists-caras-compositores-vol-6": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:29.748Z"
+    "resolvedAt": "2026-03-27T10:54:28.663Z"
   },
   "cd-1571-various-artists-caras-compositores-vol-8": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:31.631Z"
+    "resolvedAt": "2026-03-27T10:54:31.375Z"
   },
   "cd-1572-various-artists-caras-compositores-vol-9": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:33.517Z"
+    "resolvedAt": "2026-03-27T10:54:34.094Z"
   },
   "cd-1573-various-artists-caras-tenores-vol-3": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:35.404Z"
+    "resolvedAt": "2026-03-27T10:54:36.932Z"
   },
   "cd-1574-various-artists-carnaval-sua-historia-su": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:37.311Z"
+    "resolvedAt": "2026-03-27T10:54:39.672Z"
   },
   "cd-1575-various-artists-caymmi-em-familia": {
     "url": "http://coverartarchive.org/release/bc92cb95-428f-4894-acda-5c920f8d3ac2/12166394475-500.jpg",
@@ -7880,19 +7880,19 @@
     "resolvedAt": "2026-03-26T18:40:42.185Z"
   },
   "cd-1576-various-artists-cazas-de-cazuza-a-opera-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:40:44.240Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/13/4c/01/134c015f-d575-57de-58cd-976b93f2cebd/8720205641175.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:40.987Z"
   },
   "cd-1577-various-artists-celebrating-gershwin": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:40:46.253Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music111/v4/a2/2f/14/a22f145b-cff7-b3c9-6550-b25e521a87d9/634457473607.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:42.257Z"
   },
   "cd-1578-various-artists-chiquinha-em-revista": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:40:48.143Z"
+    "resolvedAt": "2026-03-27T10:54:45.102Z"
   },
   "cd-1579-various-artists-come-together-guitar-tri": {
     "url": "http://coverartarchive.org/release/3ee2fdfc-7714-431f-83d3-07b36a1e8700/28003308850-500.jpg",
@@ -7907,7 +7907,7 @@
   "cd-1581-various-artists-edward-hopper-and-the-mu": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:41:00.395Z"
+    "resolvedAt": "2026-03-27T10:54:48.638Z"
   },
   "cd-1582-various-artists-globo-collection-jazz": {
     "url": "http://coverartarchive.org/release/ec72d412-2726-4ff6-97e1-ea1c5939975c/10361024736-500.jpg",
@@ -7915,14 +7915,14 @@
     "resolvedAt": "2026-03-26T18:41:04.988Z"
   },
   "cd-1583-various-artists-greatest-hits-the-chorus": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:07.156Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/fb/93/0f/fb930f12-74b1-ef6e-774e-fb22302f33e9/14DMGIM05636.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:49.879Z"
   },
   "cd-1584-various-artists-grupo-corpo-cantigas-de-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:41:08.988Z"
+    "resolvedAt": "2026-03-27T10:54:52.817Z"
   },
   "cd-1585-various-artists-interview-jazz-collectio": {
     "url": "http://coverartarchive.org/release/d08ed35a-80b1-49aa-9309-41909dacc2b1/25946784479-500.jpg",
@@ -7930,14 +7930,14 @@
     "resolvedAt": "2026-03-26T18:41:13.591Z"
   },
   "cd-1586-various-artists-italian-opera-choruses": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:15.899Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music71/v4/a7/a0/a8/a7a0a8fe-2a73-d8e8-8b66-514602d9ae82/084247952209.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:54.239Z"
   },
   "cd-1587-various-artists-jazz-no-municipal-volume": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:17.781Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/93/ce/ad/93cead11-8818-ebc7-63a6-a7b145a82bad/7891161727799.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:55.611Z"
   },
   "cd-1588-various-artists-jazz-to-the-world": {
     "url": "http://coverartarchive.org/release/0bfa1407-815a-4725-bda6-f2a562989f25/18504233430-500.jpg",
@@ -7945,109 +7945,109 @@
     "resolvedAt": "2026-03-26T18:41:22.267Z"
   },
   "cd-1589-various-artists-joias-da-musica-vol-1": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:24.403Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/09/ac/be/09acbe7f-bc69-a99d-6f72-76236fef68e1/192562262269.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:56.866Z"
   },
   "cd-1590-various-artists-joias-da-musica-vol-10": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:26.623Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/09/ac/be/09acbe7f-bc69-a99d-6f72-76236fef68e1/192562262269.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:58.124Z"
   },
   "cd-1591-various-artists-joias-da-musica-vol-2": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:28.881Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/75/e8/38/75e838d4-4f47-0c62-d7ba-3f5960c2ab0a/190374643689.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:54:59.470Z"
   },
   "cd-1592-various-artists-joias-da-musica-vol-3": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:30.848Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/75/e8/38/75e838d4-4f47-0c62-d7ba-3f5960c2ab0a/190374643689.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:00.788Z"
   },
   "cd-1593-various-artists-joias-da-musica-vol-4": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:32.743Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/75/e8/38/75e838d4-4f47-0c62-d7ba-3f5960c2ab0a/190374643689.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:02.059Z"
   },
   "cd-1594-various-artists-joias-da-musica-vol-5": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:35.163Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/75/e8/38/75e838d4-4f47-0c62-d7ba-3f5960c2ab0a/190374643689.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:03.331Z"
   },
   "cd-1595-various-artists-joias-da-musica-vol-6": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:37.125Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/75/e8/38/75e838d4-4f47-0c62-d7ba-3f5960c2ab0a/190374643689.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:04.680Z"
   },
   "cd-1596-various-artists-joias-da-musica-vol-7": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:38.967Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/09/ac/be/09acbe7f-bc69-a99d-6f72-76236fef68e1/192562262269.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:05.948Z"
   },
   "cd-1597-various-artists-joias-da-musica-vol-8": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:40.793Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/09/ac/be/09acbe7f-bc69-a99d-6f72-76236fef68e1/192562262269.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:07.199Z"
   },
   "cd-1598-various-artists-joias-da-musica-vol-9": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:43.014Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music30/v4/75/e8/38/75e838d4-4f47-0c62-d7ba-3f5960c2ab0a/190374643689.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:08.509Z"
   },
   "cd-1599-various-artists-jungle-jazz-volume-3": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:44.936Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/e2/a4/cb/e2a4cba3-a7b3-7948-c5de-2625c00fe267/06PNDIM00019.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:09.834Z"
   },
   "cd-1600-various-artists-les-plus-grands-moments-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:41:47.669Z"
+    "resolvedAt": "2026-03-27T10:55:14.141Z"
   },
   "cd-1601-various-artists-memoria-do-piano-brasile": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:49.610Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/fe/37/34/fe373493-38b6-b368-2210-e9be0fbcb953/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:18.879Z"
   },
   "cd-1602-various-artists-music-architecture-wrigh": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:41:51.528Z"
+    "resolvedAt": "2026-03-27T10:55:21.674Z"
   },
   "cd-1603-various-artists-nostalgias-tangos": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:54.017Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/58/7c/e1/587ce150-44d9-e1fa-966c-18b72cd666ac/00602547876706.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:22.951Z"
   },
   "cd-1604-various-artists-o-que-voce-quer-saber-de": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:41:56.018Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/fd/40/35/fd40356c-1a79-14ac-a10d-879012623901/195081542355.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:24.201Z"
   },
   "cd-1605-various-artists-ola-belem-cantos-do-port": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:41:58.028Z"
+    "resolvedAt": "2026-03-27T10:55:26.989Z"
   },
   "cd-1606-various-artists-os-sambas-que-fizeram-su": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:41:59.876Z"
+    "resolvedAt": "2026-03-27T10:55:29.789Z"
   },
   "cd-1607-various-artists-picasso-a-musica-de-seu-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:01.775Z"
+    "resolvedAt": "2026-03-27T10:55:32.591Z"
   },
   "cd-1608-various-artists-projeto-enlace-o-mar-a-m": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:03.667Z"
+    "resolvedAt": "2026-03-27T10:55:35.437Z"
   },
   "cd-1609-various-artists-saudade-de-tom-vinicius": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:05.548Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/b5/be/69/b5be690a-df79-ef44-6b80-30c20ddccc9d/7891397009027.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:36.764Z"
   },
   "cd-1610-various-artists-songbook-noel": {
     "url": "http://coverartarchive.org/release/7580349f-eb02-4f36-9ea4-ab5c67be1723/3992399007-500.jpg",
@@ -8057,22 +8057,22 @@
   "cd-1611-various-artists-stardust-the-classic-dec": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:12.843Z"
+    "resolvedAt": "2026-03-27T10:55:39.677Z"
   },
   "cd-1612-various-artists-super-hits-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:15.276Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/c0/54/97/c05497aa-c19f-bf4f-de29-71edf30fbefb/075679688767.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:41.228Z"
   },
   "cd-1613-various-artists-swingin-round-switzerlan": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:17.230Z"
+    "resolvedAt": "2026-03-27T10:55:44.172Z"
   },
   "cd-1614-various-artists-talkin-verve-groovy": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:19.408Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/de/75/67/de756796-3069-6934-302d-1a5c4c75b518/06UMGIM07679.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:45.666Z"
   },
   "cd-1615-various-artists-the-glory-of-gershwin": {
     "url": "http://coverartarchive.org/release/e547b129-3fdb-46a2-9434-7f0ddfe4e2c1/14454121786-500.jpg",
@@ -8080,9 +8080,9 @@
     "resolvedAt": "2026-03-26T18:42:24.510Z"
   },
   "cd-1616-various-artists-trilhas": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:26.507Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/68/19/43/68194388-efa7-3afe-8a15-a4c3eebef1f6/886445915211.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:46.968Z"
   },
   "cd-1617-various-artists-tutto-fellini": {
     "url": "https://coverartarchive.org/release/ace60879-8673-4ada-8ceb-4eb83d63e0d4/43990032228-500.jpg",
@@ -8092,27 +8092,27 @@
   "cd-1618-various-artists-utopia-brasileira": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:34.142Z"
+    "resolvedAt": "2026-03-27T10:55:49.755Z"
   },
   "cd-1619-various-artists-valsas-brasileiras-vol-2": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:36.049Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/39/16/22/mzi.izbhrukz.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:51.355Z"
   },
   "cd-1620-various-artists-violoes-projeto-memoria-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:37.957Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/v4/94/ad/dc/94addcb8-b3ce-1ba7-e4e9-46f5b4548d6e/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:52.614Z"
   },
   "cd-1621-various-artists-weril-90-anos-em-musica": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:39.831Z"
+    "resolvedAt": "2026-03-27T10:55:55.330Z"
   },
   "cd-1622-various-andrew-lloyd-webber-the-premiere": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:41.715Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/3a/6e/1b/3a6e1b7b-db1d-aa93-c21d-09950a6ae890/602567004370.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:56.706Z"
   },
   "cd-1623-billy-vaughn-la-paloma": {
     "url": "http://coverartarchive.org/release/053bade5-3d32-435d-b27a-a34b9d1cc64a/32802537809-500.jpg",
@@ -8120,9 +8120,9 @@
     "resolvedAt": "2026-03-26T18:42:47.653Z"
   },
   "cd-1624-velha-guarda-do-g-r-c-e-s-unidos-do-peru": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:49.714Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/e4/d7/81/e4d781e8-bd3f-486a-cd18-e9b3a7d12b34/00731452735126.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:55:58.055Z"
   },
   "cd-1625-caetano-veloso-a-foreign-sound": {
     "url": "http://coverartarchive.org/release/b79b6396-45c4-3dda-90b1-9f41f3909760/29011529094-500.jpg",
@@ -8132,12 +8132,12 @@
   "cd-1626-caetano-veloso-caetano-canta-cd1": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:42:57.038Z"
+    "resolvedAt": "2026-03-27T10:56:00.795Z"
   },
   "cd-1627-caetano-veloso-fina-estampa": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:42:59.157Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/f8/0f/4c/f80f4c80-9565-6873-1dd9-53a6279ce72b/00731452274526.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:02.031Z"
   },
   "cd-1628-caetano-veloso-livro": {
     "url": "http://coverartarchive.org/release/45655a5b-f028-447f-a0dd-5d9c15196227/13137542520-500.jpg",
@@ -8147,7 +8147,7 @@
   "cd-1629-caetano-veloso-millenium": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:43:05.616Z"
+    "resolvedAt": "2026-03-27T10:56:05.040Z"
   },
   "cd-1630-caetano-veloso-orfeu": {
     "url": "http://coverartarchive.org/release/1ec43793-5f07-4187-bc8f-3f44d87179e8/32473995497-500.jpg",
@@ -8167,12 +8167,12 @@
   "cd-1633-guilherme-vergueiro-love-carnival-dreams": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:43:21.392Z"
+    "resolvedAt": "2026-03-27T10:56:08.125Z"
   },
   "cd-1634-victor-assis-brasil-victor-assis-brasil-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:43:23.372Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/4a/68/c4/4a68c4f7-98f4-a687-4c27-b58c8958774e/3034925_cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:09.898Z"
   },
   "cd-1635-village-people-the-best-of-village-peopl": {
     "url": "http://coverartarchive.org/release/510a4ca9-6539-497d-953f-54b787077f0f/19827651614-500.jpg",
@@ -8180,19 +8180,19 @@
     "resolvedAt": "2026-03-26T18:43:27.861Z"
   },
   "cd-1636-vitor-ramil-delibab": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:43:30.207Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music3/v4/43/79/25/43792541-62b5-ae3d-9020-52ddc1f9888d/7898260720072.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:11.559Z"
   },
   "cd-1637-vocal-s-a-vocal-s-a": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:43:32.107Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/08/8c/24/088c2405-2e33-801b-5c38-e967f2c01e69/191404113974.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:12.898Z"
   },
   "cd-1638-vulgue-tostoi-sistema-delirante-amplo-e-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:43:34.026Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music4/v4/2b/e3/5e/2be35e64-2263-6c17-a7bc-1c4f2abcf9ef/cover.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:14.149Z"
   },
   "cd-1639-wado-cinema-auditivo": {
     "url": "http://coverartarchive.org/release/1561c634-788b-45fc-983e-bad045191898/3998119456-500.jpg",
@@ -8220,19 +8220,19 @@
     "resolvedAt": "2026-03-26T18:43:56.991Z"
   },
   "cd-1644-wanderlea-nova-estacao": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:43:59.182Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/e7/b7/19/e7b719b8-33be-4d49-efc4-927597c2a1bc/7898469900633.png/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:15.474Z"
   },
   "cd-1645-wayne-shorter-et-cetera": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:44:01.058Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/04/d3/db/04d3db83-c289-4736-20ed-221daeb397b9/00602537484188.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:16.785Z"
   },
   "cd-1646-wayne-shorter-high-life": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:44:06.989Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/9c/b5/b3/9cb5b305-4a53-7f9f-b349-1a38100bc4d0/00731452922427.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:18.036Z"
   },
   "cd-1647-wayne-shorter-joy-ryder": {
     "url": "http://coverartarchive.org/release/2f45597b-725e-46f4-b706-ab46dabf2380/7047628946-500.jpg",
@@ -8250,14 +8250,14 @@
     "resolvedAt": "2026-03-26T18:44:23.862Z"
   },
   "cd-1650-wayne-shorter-quartet-beyond-the-sound-b": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:44:26.310Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/59/bf/8d/59bf8dce-f868-080f-9fd3-ae5ad50547e0/00602498831052.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:19.515Z"
   },
   "cd-1651-weather-report-0-3541666667": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:44:28.164Z"
+    "resolvedAt": "2026-03-27T10:56:22.878Z"
   },
   "cd-1652-weather-report-black-market": {
     "url": "http://coverartarchive.org/release/b91ff175-662b-4aa4-ac36-f53e7d6f1ceb/30592014978-500.jpg",
@@ -8275,14 +8275,14 @@
     "resolvedAt": "2026-03-26T18:44:42.734Z"
   },
   "cd-1655-weather-report-this-is-jazz": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:44:45.056Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/4b/60/7e/mzi.unyilxam.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:24.114Z"
   },
   "cd-1656-weather-report-weather-report": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:44:47.162Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/7a/23/c2/mzi.pmhnubnn.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:25.351Z"
   },
   "cd-1657-the-white-stripes-the-white-stripes": {
     "url": "http://coverartarchive.org/release/e63a68de-41c7-37ca-a362-90afcf9c7700/2976907950-500.jpg",
@@ -8290,9 +8290,9 @@
     "resolvedAt": "2026-03-26T18:44:53.500Z"
   },
   "cd-1658-the-who-quadrophenia": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:44:55.750Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/0e/21/7d/0e217d98-4873-2eb7-5c24-16969b47cb7e/00602537790203.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:26.647Z"
   },
   "cd-1659-the-who-then-now": {
     "url": "http://coverartarchive.org/release/aed2da31-db0e-4888-90ec-17f6d82f3ad3/27025547389-500.jpg",
@@ -8317,12 +8317,12 @@
   "cd-1663-wolfgang-amadeus-mozart-armin-jordan-la-": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:45:19.833Z"
+    "resolvedAt": "2026-03-27T10:56:29.476Z"
   },
   "cd-1664-wolfgang-amadeus-mozart-bruno-walter-col": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:45:22.004Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/08/52/a3/0852a397-576e-b96c-7c8d-3e6b564bbd54/00888072391604.rgb.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:30.830Z"
   },
   "cd-1665-stevie-wonder-conversation-peace": {
     "url": "https://coverartarchive.org/release/43f781a3-7978-31c2-9713-eaff5e2215ae/41133741530-500.jpg",
@@ -8360,9 +8360,9 @@
     "resolvedAt": "2026-03-26T18:45:52.367Z"
   },
   "cd-1672-wynton-marsalis-soul-gestures-1-thick-in": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:45:54.904Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/e5/db/ad/mzi.oljqizjt.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:32.315Z"
   },
   "cd-1673-wynton-marsalis-standard-time-vol-2-inti": {
     "url": "http://coverartarchive.org/release/f97398ae-0b71-4dc4-acfd-09818a3122c9/31406606893-500.jpg",
@@ -8370,14 +8370,14 @@
     "resolvedAt": "2026-03-26T18:45:59.579Z"
   },
   "cd-1674-wynton-marsalis-standard-time-vol-4-mars": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:01.771Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/4f/df/05/mzi.rrjrkgfd.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:33.626Z"
   },
   "cd-1675-wynton-marsalis-uptown-rule": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:03.617Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/a6/08/d7/a608d712-e567-c3fa-4df0-094e3f3ff157/074644797626.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:34.948Z"
   },
   "cd-1676-wynton-marsalis-quartet-the-magic-hour": {
     "url": "http://coverartarchive.org/release/f4de1e48-e1b9-4c9d-9230-726c9729d8f1/25455217661-500.jpg",
@@ -8385,29 +8385,29 @@
     "resolvedAt": "2026-03-26T18:46:08.820Z"
   },
   "cd-1677-wynton-marsalis-septet-in-this-house-on-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:11.203Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/77/93/5f/77935fa1-40e7-7c44-ccb6-d86869e70c7e/192562195505.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:36.218Z"
   },
   "cd-1678-wynton-marsalis-the-lincoln-center-jazz-": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:13.144Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/a4/ac/f8/mzi.ogfqenxa.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:37.544Z"
   },
   "cd-1679-yamandu-costa-dominguinhos-yamandu-domin": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:14.986Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/20/87/12/2087129c-cecd-7cb6-efc4-1ea14f8aabd2/dj.vwxsehkh.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:38.808Z"
   },
   "cd-1680-yamandu-costa-hamilton-de-holanda-luz-da": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:46:16.894Z"
+    "resolvedAt": "2026-03-27T10:56:41.822Z"
   },
   "cd-1681-yes-fragile": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:19.057Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/10/a4/3d/10a43d25-f05e-612c-799c-4c3687a3aeb6/603497886128.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:43.117Z"
   },
   "cd-1682-yes-the-yes-album": {
     "url": "http://coverartarchive.org/release/d70a698c-f023-4a89-8e47-7de5a0858197/10710077256-500.jpg",
@@ -8415,14 +8415,14 @@
     "resolvedAt": "2026-03-26T18:46:23.885Z"
   },
   "cd-1683-yoyo-borobia-yoyo-borobia": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:26.209Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music49/v4/9b/99/71/9b99713e-3b6e-eaf4-b7ce-4de801a9e2fb/0.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:44.443Z"
   },
   "cd-1684-yuri-da-cunha-kuma-kwa-kie": {
     "url": null,
     "source": "none",
-    "resolvedAt": "2026-03-26T18:46:28.325Z"
+    "resolvedAt": "2026-03-27T10:56:47.209Z"
   },
   "cd-1685-frank-zappa-joe-s-garage-acts-i-ii-iii": {
     "url": "http://coverartarchive.org/release/5b53d319-3f9c-47eb-9a96-8341d7be58f7/22676417957-500.jpg",
@@ -8430,9 +8430,9 @@
     "resolvedAt": "2026-03-26T18:46:33.494Z"
   },
   "cd-1686-ze-paulo-becker-pra-tudo-ficar-bem": {
-    "url": null,
-    "source": "none",
-    "resolvedAt": "2026-03-26T18:46:35.534Z"
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/cc/1e/c2/mzi.hjnlwnuv.jpg/600x600bb.jpg",
+    "source": "itunes",
+    "resolvedAt": "2026-03-27T10:56:48.463Z"
   },
   "dvd-0-2001-a-space-odyssey": {
     "url": "https://image.tmdb.org/t/p/w500/ve72VxNqjGM69Uky4WTo2bK6rfq.jpg",

--- a/scripts/resolve-artwork.ts
+++ b/scripts/resolve-artwork.ts
@@ -11,6 +11,11 @@
  *
  * Environment variables (from .env.local or CI secrets):
  *   TMDB_API_KEY — required for DVD poster resolution
+ *
+ * CLI flags:
+ *   --delay <ms>  Override rate-limit delay for iTunes/TMDB (default: 200ms/50ms).
+ *                  MusicBrainz delay is clamped to ≥1200ms regardless.
+ *                  Previously missed items (url: null in cache) are always retried.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs'
@@ -41,6 +46,26 @@ function loadEnvLocal() {
 
 loadEnvLocal()
 
+// ── CLI args ─────────────────────────────────────────────────────────────
+
+function parseCliArgs() {
+  const args = process.argv.slice(2)
+  let delay: number | undefined
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--delay' && args[i + 1]) {
+      delay = parseInt(args[i + 1], 10)
+      if (isNaN(delay) || delay < 0) {
+        console.error('Error: --delay must be a non-negative integer (ms)')
+        process.exit(1)
+      }
+      i++
+    }
+  }
+  return { delay }
+}
+
+const cliArgs = parseCliArgs()
+
 // ── Config ───────────────────────────────────────────────────────────────
 
 const ROOT = join(import.meta.dirname, '..')
@@ -52,10 +77,10 @@ const CACHE_PATH = join(ROOT, 'artwork-cache.json')
 const TMDB_API_KEY = process.env.TMDB_API_KEY || ''
 const TMDB_IMG_BASE = 'https://image.tmdb.org/t/p/w500'
 
-// Rate limit delays (ms)
-const ITUNES_DELAY = 200
-const MUSICBRAINZ_DELAY = 1200 // >1s per their policy
-const TMDB_DELAY = 50
+// Rate limit delays (ms) — override iTunes/TMDB with --delay flag
+const ITUNES_DELAY = cliArgs.delay ?? 200
+const MUSICBRAINZ_DELAY = Math.max(cliArgs.delay ?? 1200, 1200) // never below 1200 per their policy
+const TMDB_DELAY = cliArgs.delay ?? 50
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -191,6 +216,7 @@ async function main() {
   const cachedCount = Object.keys(cache).length
 
   console.log(`  Loaded ${cds.length} CDs, ${dvds.length} DVDs, ${cachedCount} cached entries`)
+  console.log(`  Delays: iTunes=${ITUNES_DELAY}ms, MusicBrainz=${MUSICBRAINZ_DELAY}ms, TMDB=${TMDB_DELAY}ms`)
 
   // ── Resolve CD artwork ──────────────────────────────────────────────
 
@@ -205,14 +231,12 @@ async function main() {
     const cd = cds[i]
     const prefix = `  [${i + 1}/${cds.length}]`
 
-    // Check cache
-    if (cache[cd.id]) {
+    // Check cache — skip only if already resolved with artwork
+    if (cache[cd.id]?.url) {
       const entry = cache[cd.id]
-      if (entry.url) {
-        cd.artworkUrl = entry.url
-        cd.artworkSource = entry.source
-        cdResolved++
-      }
+      cd.artworkUrl = entry.url!
+      cd.artworkSource = entry.source
+      cdResolved++
       cdCached++
       continue
     }
@@ -280,14 +304,12 @@ async function main() {
       const dvd = dvds[i]
       const prefix = `  [${i + 1}/${dvds.length}]`
 
-      // Check cache
-      if (cache[dvd.id]) {
+      // Check cache — skip only if already resolved with poster
+      if (cache[dvd.id]?.url) {
         const entry = cache[dvd.id]
-        if (entry.url) {
-          dvd.posterUrl = entry.url
-          dvd.posterSource = entry.source
-          dvdResolved++
-        }
+        dvd.posterUrl = entry.url!
+        dvd.posterSource = entry.source
+        dvdResolved++
         dvdCached++
         continue
       }


### PR DESCRIPTION
## Summary
- Add optional `--delay <ms>` CLI flag to `resolve-artwork.ts` to override rate-limit delays (iTunes/TMDB). MusicBrainz delay is clamped to ≥1200ms per their policy.
- Changed cache logic to retry previously missed entries (`url: null`) instead of skipping them — only successfully resolved artwork is treated as cached.
- Ran with `--delay 1000` to retry 689 previously missed CDs: **1,437/1,687 CDs now have artwork** (up from 998, +439 new).

## Test plan
- [ ] `npm run prepare-data && npx tsx scripts/resolve-artwork.ts` — verify default behavior unchanged
- [ ] `npx tsx scripts/resolve-artwork.ts --delay 1000` — verify custom delay is applied
- [ ] `npm run build` — verify site builds with updated artwork cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)